### PR TITLE
Fixes image preload warning

### DIFF
--- a/src/app/PreloadResources.tsx
+++ b/src/app/PreloadResources.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import ReactDOM from "react-dom"
+
+export function PreloadResources() {
+    ReactDOM.preload('/assets/texture/background.png', { as: 'image' })
+    ReactDOM.preload('/assets/texture/grid.png', { as: 'image' })
+   
+    return null
+}
+  

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import Head from "next/head";
+import { PreloadResources } from "./PreloadResources";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -17,10 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <Head>
-        <link rel="preload" href="/assets/texture/background.png" as="image" />
-        <link rel="preload" href="/assets/texture/grid.png" as="image" />
-      </Head>
+      <PreloadResources />
       <body className={`${inter.className}`} style={{
         backgroundImage: "url(/assets/texture/background.png)",
         backgroundSize: "100vw 100vh"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,6 @@ export default function Home() {
     }
   };
 
-
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">


### PR DESCRIPTION
Gets rid of this error:

```
Warning: You're using `next/head` inside the `app` directory, please migrate to the Metadata API. See https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-3-migrating-nexthead for more details.
```


reference: https://github.com/vercel/next.js/discussions/57877