### PR TITLE
Fixes auto redirection mechanism

### DIFF
--- a/src/AuthProtectedComponent.tsx
+++ b/src/AuthProtectedComponent.tsx
@@ -1,19 +1,18 @@
-import { redirect } from "next/navigation";
 import { getSession } from "./auth";
+import { PreLoginHelper } from "./app/login/RedirectHelper";
 
 interface AuthProtectedComponentProps { 
-    route: string;
     children: React.ReactNode 
 }
 
 
 export default async function AuthProtectedComponent(
-    { route, children }: AuthProtectedComponentProps)
+    { children }: AuthProtectedComponentProps)
 {
     const session = await getSession();
 
     if (!session) {
-        redirect(`/login${route ? `?redirect=${route}` : ""}`);
+        return <PreLoginHelper />
     }
 
     return <>{children}</>;

--- a/src/app/floorplan/page.tsx
+++ b/src/app/floorplan/page.tsx
@@ -2,7 +2,7 @@ import PageClient from "@/app/floorplan/PageClient";
 import AuthProtectedComponent from "@/AuthProtectedComponent";
 
 export default function Page() {
-    return <AuthProtectedComponent route={"/floorplan"}>
+    return <AuthProtectedComponent>
         <PageClient />;
     </AuthProtectedComponent>
 }

--- a/src/app/house_layout/[room]/layout.tsx
+++ b/src/app/house_layout/[room]/layout.tsx
@@ -8,8 +8,6 @@ import SelectedContainer from "./SelectedContainer";
 
 export default async function RoomLayout({ params, children }: PropsWithChildren<{ params: { room: string } }>) {
 
-  // console.log("params in [room] layout - get from parent:", params);
-  
   const roomId = params.room;
   const containersData = await fetchContainersByRoom(roomId);
 

--- a/src/app/house_layout/layout.tsx
+++ b/src/app/house_layout/layout.tsx
@@ -36,7 +36,7 @@ async function DataLoader({ children }: { children: React.ReactNode }) {
 }
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-    return <AuthProtectedComponent route={"/house_layout"}>
+    return <AuthProtectedComponent>
         {<DataLoader >{ children }</DataLoader>}
     </AuthProtectedComponent>
 }

--- a/src/app/login/RedirectHelper.tsx
+++ b/src/app/login/RedirectHelper.tsx
@@ -1,10 +1,25 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import {  useMount, useSearchParam } from "react-use";
+import { redirect, usePathname, useRouter } from "next/navigation";
+import {  useMount } from "react-use";
 
 interface RedirectHelperProps {
     isLogged: boolean;
+}
+
+/**
+ * Remembers the current page URL before redirecting the user to the login page.
+ * @returns {null}
+ */
+export function PreLoginHelper(): null {
+    const currentPathname = usePathname();
+
+    useMount(() => {
+        window.localStorage.setItem("redirect", currentPathname);
+        redirect("/login");
+    });
+
+    return null;
 }
 
 /* This component is used to redirect the user to the page they were trying to access before logging in.
@@ -12,16 +27,11 @@ interface RedirectHelperProps {
  it is not supposed to be used in any other context.
  */
 export default function RedirectHelper({ isLogged }: RedirectHelperProps) {
-    const redirect = useSearchParam("redirect");
     const router = useRouter();
 
     const redirectValue = window.localStorage.getItem("redirect");
 
     useMount(() => {
-        if (!isLogged && redirect) {
-            window.localStorage.setItem("redirect", redirect);
-            return;
-        }
         if (isLogged && redirectValue) {
             window.localStorage.removeItem("redirect");
             router.push(redirectValue);

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,3 +1,0 @@
-export function extractPathFromDirectory(directory: string) {
-    return (directory.match("app([/\\\\].*)") ?? [""])[1].replace(/\\/g, "/");
-}


### PR DESCRIPTION
Now we rely on a client-side component to detect and memorize the URL before login. A client-side component can always acquire the full URL. This client-side component is always responsible for actually redirecting to the `/login` page.