### PR TITLE
introduce a new primary variant.

### DIFF
--- a/src/app/new_house/LayoutOptionCard.tsx
+++ b/src/app/new_house/LayoutOptionCard.tsx
@@ -12,14 +12,14 @@ interface LayoutOptionCardProps {
 export default function LayoutOptionCard({ option, layoutId, isSelected = false, onClick }: LayoutOptionCardProps) {
   return (
     <Card
-      variant={isSelected ? "secondary" : "default"}
+      variant={isSelected ? "primary" : "default"}
       data-layout-id={layoutId}
       className="cursor-pointer transition-all duration-200"
       onClick={onClick}
     >
       <CardHeader className="text-center">
         <div className="flex justify-center mb-4">
-          <div className="relative w-32 h-24 overflow-hidden rounded-lg border-2 border-gray-200">
+          <div className="relative w-32 h-24 overflow-hidden">
             <Image
               src={option.floorplanPicture}
               alt={`${option.name} floor plan`}

--- a/src/app/ui_style/page.tsx
+++ b/src/app/ui_style/page.tsx
@@ -27,7 +27,7 @@ export default function UIStyleShowcase() {
       {/* CARD */}
       <section className="flex flex-col items-center gap-6 w-full max-w-4xl">
         <h2 className="text-2xl font-bold">Card</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full">
           <Card>
             <CardHeader>
               <CardTitle>Default Card</CardTitle>
@@ -41,6 +41,22 @@ export default function UIStyleShowcase() {
             </CardContent>
             <CardFooter>
               <span className="text-xs text-muted-foreground">Footer or actions go here</span>
+            </CardFooter>
+          </Card>
+
+          <Card variant="primary">
+            <CardHeader>
+              <CardTitle>Primary Card Variant</CardTitle>
+              <CardDescription>Highlighted card with primary button styling</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="mb-2">
+                This primary variant uses the same visual style as the primary button - with the primary accent background, white text, and inset shadows that create depth and emphasis.
+              </p>
+              <Button variant="secondary">Action</Button>
+            </CardContent>
+            <CardFooter>
+              <span className="text-xs opacity-75">Variant: Primary</span>
             </CardFooter>
           </Card>
           
@@ -59,6 +75,8 @@ export default function UIStyleShowcase() {
               <span className="text-xs text-muted-foreground">Variant: Secondary</span>
             </CardFooter>
           </Card>
+          
+          
         </div>
       </section>
 

--- a/src/ui/components/card.tsx
+++ b/src/ui/components/card.tsx
@@ -20,6 +20,11 @@ const cardVariants = cva(
           "bg-cyan-300",
           "shadow-[0_2px_8px_0_rgba(0,0,0,0.15)_inset,2px_-2px_8px_0_color-mix(in_oklch,var(--color-cyan-300),black_15%)_inset]",
           "hover:shadow-[0_4px_12px_0_rgba(0,0,0,0.25)_inset,3px_-3px_12px_0_color-mix(in_oklch,var(--color-cyan-300),black_20%)_inset]"
+        ],
+        primary: [
+          "bg-primary-accent text-white",
+          "shadow-[-3px_3px_2px_1px_hsl(var(--highlight)/70%)_inset,3px_-3px_2px_1px_color-mix(in_oklch,hsl(var(--primary-accent)),black_30%)_inset]",
+          "hover:shadow-[-3px_3px_2px_1px_hsl(var(--highlight)/70%)_inset,3px_-3px_2px_1px_color-mix(in_oklch,hsl(var(--primary-accent)),black_30%)_inset]"
         ]
       }
     },
@@ -68,7 +73,7 @@ const CardTitle = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "text-2xl font-extrabold leading-none tracking-tight text-text-main",
+      "text-2xl font-extrabold leading-none tracking-tight",
       "[text-shadow:0.5px_0.5px_0_rgba(0,0,0,0.3),-0.5px_0.5px_0_rgba(0,0,0,0.3),0.5px_-0.5px_0_rgba(0,0,0,0.2),-0.5px_-0.5px_0_rgba(0,0,0,0.2)]",
       className
     )}
@@ -83,7 +88,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-base text-text-main/80 font-medium", className) }
+    className={cn("text-base font-medium", className) }
     {...props}
   />
 ))


### PR DESCRIPTION
### TL;DR

Added a new primary card variant and updated the layout option card styling to use the new variant.

### What changed?

- Added a new `primary` variant to the Card component with a distinct visual style using the primary accent color, white text, and inset shadows
- Updated the `LayoutOptionCard` component to use the new primary variant when selected (instead of secondary)
- Removed the border from the floor plan image container in `LayoutOptionCard`
- Updated the UI style showcase page to display the new primary card variant

### Preview

<img width="2236" height="1795" alt="image" src="https://github.com/user-attachments/assets/ea8fedd1-01a5-4450-a326-298bf153b4f4" />


### How to test?

1. Visit the UI style showcase page to see the new primary card variant
2. Navigate to the new house flow and verify that selected layout options now use the primary card styling

### Why make this change?

The primary card variant provides better visual hierarchy and emphasis for selected items. By using the primary accent color for selected layout options, we create a more intuitive and consistent user experience that aligns with our design system's button styling. 