### PR TITLE
Fixes some missing styles during recent iterations.

### DIFF
--- a/src/app/ui_style/page.tsx
+++ b/src/app/ui_style/page.tsx
@@ -40,7 +40,7 @@ export default function UIStyleShowcase() {
       {/* CARD */}
       <section className="flex flex-col items-center gap-6 w-full max-w-4xl">
         <h2 className="text-2xl font-bold">Card</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full items-start">
           <Card>
             <CardHeader>
               <CardTitle>Default Card</CardTitle>
@@ -96,7 +96,7 @@ export default function UIStyleShowcase() {
       {/* BUBBLE */}
       <section className="flex flex-col items-center gap-6 w-full max-w-4xl">
         <h2 className="text-2xl font-bold">Bubble Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full items-start">
           <Bubble variant="default">
             <h3 className="text-xl font-bold mb-2 text-text-main">Default Bubble</h3>
             <p className="text-text-main/80">Rounded rectangle with realistic bubble appearance using box-shadow and shine effects.</p>
@@ -129,7 +129,7 @@ export default function UIStyleShowcase() {
       {/* ICONS */}
       <section className="flex flex-col items-center gap-6 w-full max-w-4xl">
         <h2 className="text-2xl font-bold">Icons</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full items-start">
           <div className="flex flex-col items-center gap-4">
             <h3 className="text-lg font-bold">Color Variants</h3>
             <div className="flex gap-4 items-center justify-center">

--- a/src/ui/components/button.tsx
+++ b/src/ui/components/button.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/utils/tailwind"
 
 // Base button styles
 const buttonBaseStyles = [
-  "relative z-10 inline-flex items-center justify-center font-bold overflow-visible",
+  "relative z-20 inline-flex items-center justify-center font-bold overflow-visible",
   "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-outline focus-visible:ring-offset-2",
   "transition-all duration-200 ease-out active:translate-y-0.5",
   "border-4 border-border rounded-full"
@@ -19,7 +19,7 @@ const buttonVariants = cva(buttonBaseStyles, {
       primary: [
         "bg-primary-accent text-white",
         "[text-shadow:0.5px_0.5px_0_rgba(0,0,0,0.3),-0.5px_0.5px_0_rgba(0,0,0,0.3),0.5px_-0.5px_0_rgba(0,0,0,0.2),-0.5px_-0.5px_0_rgba(0,0,0,0.2)]",
-        "shadow-[-3px_3px_2px_1px_hsl(var(--highlight)/70%)_inset,3px_-3px_2px_1px_color-mix(in_oklch,hsl(var(--primary-accent)),black_30%)_inset]",
+        "shadow-[-2px_2px_1px_0.5px_hsl(var(--highlight)/60%)_inset,2px_-2px_1px_0.5px_color-mix(in_oklch,hsl(var(--primary-accent)),black_25%)_inset]",
         "hover:scale-[1.02] hover:shadow-[-3px_3px_2px_1px_hsl(var(--highlight)/70%)_inset,3px_-3px_2px_1px_color-mix(in_oklch,hsl(var(--primary-accent)),black_30%)_inset]",
         "active:shadow-inner active:shadow-black/10",
         "disabled:bg-primary-accent/70 disabled:text-white/60 disabled:cursor-not-allowed",
@@ -66,7 +66,7 @@ const buttonVariants = cva(buttonBaseStyles, {
 // Shadow variants using cva
 const shadowVariants = cva(
   [
-    "z-0 rounded-full blur-xs translate-y-1.5 scale-x-105 origin-bottom pointer-events-none",
+    "absolute inset-0 z-10 bg-shadow/60 rounded-full blur-xs translate-y-1.5 scale-x-105 origin-bottom",
     "group-hover/button:translate-y-2 group-hover/button:scale-x-110 group-hover/button:blur-[6px] group-hover/button:opacity-80",
     "group-disabled/button:opacity-20 group-disabled/button:translate-y-0.5 group-disabled/button:scale-x-100 group-disabled/button:blur-none",
     "transition-all duration-200 ease-out"
@@ -98,23 +98,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button"
     
     return (
-
-      <div className={cn("relative inline-block group/button", disabled && "group-disabled/button")}>
-        {/* Floating shadow */}
-        <div 
-          className={cn(
-            shadowVariants({ variant }),
-            className
-          )} 
-        />
-        
+      <div className={cn("relative group/button inline-block", disabled && "group-disabled/button")}>
         {/* Button with highlight and border */}
         <Comp
           ref={ref}
           disabled={disabled}
           className={cn(
             buttonVariants({ variant, size }),
-            "relative z-10 block",
             className
           )}
           {...props}
@@ -122,6 +112,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           {children}
         </Comp>
         
+        {/* Floating shadow */}
+        <div className={cn(shadowVariants({ variant }))} />
       </div>
     )
   }

--- a/src/ui/components/card.tsx
+++ b/src/ui/components/card.tsx
@@ -41,14 +41,14 @@ export interface CardProps
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, variant, ...props }, ref) => (
     <div className="relative group">
-      {/* Floating shadow */}
-      <div className="absolute inset-0 -z-10 bg-shadow/60 rounded-3xl blur-[6px] translate-y-2 scale-x-110 origin-bottom group-hover:translate-y-3 group-hover:scale-x-115 group-hover:blur-[10px] group-hover:opacity-80 transition-all duration-200 ease-out" />
       {/* Main Card */}
       <div
         ref={ref}
         className={cn(cardVariants({ variant }), className)}
         {...props}
       />
+      {/* Floating shadow */}
+      <div className="absolute inset-0 -z-10 bg-shadow/60 rounded-3xl blur-[6px] translate-y-2 scale-x-110 origin-bottom group-hover:translate-y-3 group-hover:scale-x-115 group-hover:blur-[10px] group-hover:opacity-80 transition-all duration-200 ease-out" />
     </div>
   )
 )


### PR DESCRIPTION
### TL;DR

The shadow effects were lost in recent works. This PR ads it back.

### Before
<img width="2261" height="1784" alt="image" src="https://github.com/user-attachments/assets/1ea0dfd7-9a86-49fa-95f6-52a47523ca61" />


### After:
<img width="2454" height="1800" alt="image" src="https://github.com/user-attachments/assets/4c003ae1-d752-43bb-81eb-7ded546a9acd" />


### What changed?

- Added `items-start` to grid layouts in the UI showcase to properly align cards and bubbles
- Improved button component styling:
  - Increased z-index from 10 to 20 for better layering
  - Refined shadow effects with more subtle inset shadows
  - Repositioned the floating shadow element to appear below the button
- Updated card component by reordering the shadow element to maintain proper stacking

