### PR TITLE
Enhance polygon export by including color metadata in Floorplan V2

### DIFF
--- a/src/app/floorplan-v2/FloorplanV2Game.tsx
+++ b/src/app/floorplan-v2/FloorplanV2Game.tsx
@@ -207,7 +207,10 @@ export default function FloorplanV2Game() {
                         return {
                             id: id || 'untitled',
                             name: polygon.label,
-                            vertices: polygon.getVertices()
+                            metadata: {
+                                vertices: polygon.getVertices(),
+                                color: polygon.color
+                            }
                         };
                     }),
                     exportedAt: new Date().toISOString()


### PR DESCRIPTION
### TL;DR

Updated the polygon export format to include color information in metadata.

### What changed?

Modified the polygon export structure in `FloorplanV2Game.tsx` to store vertices and color information within a metadata object. Previously, only vertices were exported directly at the root level of each polygon object.

### How to test?

1. Create a floorplan with multiple polygons of different colors
2. Export the floorplan
3. Verify that the exported JSON includes a `metadata` object for each polygon containing both `vertices` and `color` properties

### Why make this change?

This change enhances the exported data format to preserve color information, which is important for accurately reconstructing floorplans when viewed. The "metadata" layer matches how we are currently representing it in database.