### PR TITLE
Redo Floorplan Viewer with Phaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ design/**/*.webp
 
 design/claude/*
 design/codex/*
+AGENTS.md
 
 public/assets
 scripts/symbollink.js

--- a/src/app/house_layout/FloorplanViewer.tsx
+++ b/src/app/house_layout/FloorplanViewer.tsx
@@ -1,169 +1,21 @@
 "use client";
 
-import { cn } from "@/utils/tailwind";
-import { Icon } from '@iconify-icon/react';
-import menuFoldLeft from '@iconify-icons/line-md/menu-fold-left';
-import menuUnFoldRight from '@iconify-icons/line-md/menu-unfold-right';
-import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useRef } from "react";
-import { useLatest, useMount } from "react-use";
-import { TransformComponent, TransformWrapper, ReactZoomPanPinchRef, useTransformInit, ReactZoomPanPinchState } from "react-zoom-pan-pinch";
-import Image from "next/image";
+import dynamic from "next/dynamic";
 import { HouseDef, RoomDef } from "./common";
-import { getColorByNumber } from "@/ui/colors";
-
-interface RoomProps {
-    roomId: string;
-    x: number;
-    y: number;
-    w: number;
-    h: number;
-    className?: string;
-    onClick: (roomId: string) => void;  // Change to pass room name and id
-}
-
-function Room({ roomId, x, y, w, h, className, onClick}: RoomProps) {
-    return <div className={cn("absolute cursor-pointer", className)} style={{
-        top: `${y}px`,
-        left: `${x}px`,
-        width: `${w}px`,
-        height: `${h}px`
-    }} onClick={() => onClick(roomId)} />;
-}
 
 interface FloorPlanViewerProps {
     houseDef: HouseDef;
-    isFolded: boolean;
+    isPanelOpen: boolean;
     roomDefs: RoomDef[];
-    onFold: (isFolded: boolean) => void;
+    onPanelVisibilityChange: (open: boolean) => void;
     className?: string;
 }
 
-export default function FloorplanViewer({
-    houseDef,
-    isFolded,
-    roomDefs,
-    onFold
-}: FloorPlanViewerProps) {
-    const transformComponentRef = useRef<ReactZoomPanPinchRef | null>(null);
-    const initialTransformStateRef = useRef<ReactZoomPanPinchState>(undefined);
+const DynamicFloorplanViewerGame = dynamic(
+    () => import('./FloorplanViewerGame'),
+    { ssr: false }
+);
 
-    const shrink = useCallback(() => {
-        const transformState = transformComponentRef.current?.instance.transformState;
-        if (transformState) {
-            const { positionX, positionY, scale } = transformState;
-
-            transformComponentRef.current?.setTransform(
-                positionX / 2, positionY, scale
-            )
-        }
-        onFold(true)
-    }, [onFold]);
-
-    const expand = useCallback(() => {
-        if (initialTransformStateRef.current) {
-            // If the initialTransformStateRef.current is defined, use it to set the transform
-            transformComponentRef.current?.setTransform(
-                initialTransformStateRef.current.positionX,
-                initialTransformStateRef.current.positionY,
-                1
-            );
-        } else {
-            // 0 means the animation will be instant, otherwise the centerView() will cut off the
-            // animation and cause the resetTransform() to be ignored
-            transformComponentRef.current?.resetTransform(0)
-
-            setTimeout(() => {
-                transformComponentRef.current?.centerView(1, 0);
-
-                // Acquire the initial transform state after the centerView() animation is done for the first time
-                initialTransformStateRef.current = transformComponentRef.current?.instance.transformState;
-            }, 10)
-        }
-       
-        onFold(false)
-    }, [onFold]);
-
-    const router = useRouter();
-    const pathname = usePathname();
-
-    const zoomToElement = useCallback((roomId: string) => {
-        if (!isFolded) {
-            shrink();
-        }
-
-        setTimeout(() => {
-            transformComponentRef.current?.zoomToElement(roomId);
-        }, 1);
-    }, [isFolded, shrink]);
-
-    const handleRoomClick = useCallback((roomId: string) => {
-        const parts = pathname.split("/");
-        const currentRoom = parts[2];
-        // If clicking a different room, always go to room root
-        if (currentRoom !== roomId) {
-            router.push(`/house_layout/${roomId}`);
-        }
-    }, [router, pathname]);
-
-    const handleRoomInteraction = useCallback((roomId: string) => {
-        zoomToElement(roomId);
-        handleRoomClick(roomId);
-    }, [zoomToElement , handleRoomClick]);
-
-    const handleRoomInteractionLatest = useLatest(handleRoomInteraction);
-
-    useMount(() => {
-
-        if (isFolded) {
-            return
-        } else {
-            // Acquire the initial transform state when the component is mounted.
-            // this is only done when the component is in the expanded state
-            initialTransformStateRef.current = {
-                positionX:  transformComponentRef.current?.instance.transformState.positionX!,
-                positionY: transformComponentRef.current?.instance.transformState.positionY!,
-                scale: 1,
-                previousScale: 1,
-            };
-        }
-
-        const parts = pathname.split("/");
-
-        if (parts.length > 2) {
-            const elementId = parts[2];
-
-            setTimeout(() => {
-                return handleRoomInteractionLatest.current?.(decodeURI(elementId));
-            }, 1);
-        }
-    },);
-
-    const { floorplanPicture, width, height } = houseDef;
-
-    return <div className={"relative flex justify-center items-center overflow-hidden row-span-2"} >
-        <TransformWrapper initialScale={1} limitToBounds={false} centerOnInit={true} minScale={0.5} maxScale={3}
-            ref={transformComponentRef}
-        >
-            <TransformComponent wrapperClass="h-full w-full" wrapperStyle={{
-                    width: "100%", height: "100%"
-                }}> {
-                    <div className="w-full relative">
-                        <Image src={floorplanPicture} width={width} height={height} alt="floorplan" className={"h-[750px] w-auto max-w-max transform-gpu"} />
-                        {roomDefs.map(({x, y, h, w, id}, index) => <Room key={id} roomId={id} x={x} y={y} w={w} h={h} 
-                            className={cn("opacity-50", `hover:bg-${getColorByNumber(index)}`)} onClick={handleRoomInteraction} />)}
-                    </div>
-                }
-            </TransformComponent>
-        </TransformWrapper>    
-
-        {!isFolded && <Icon icon={menuFoldLeft} width="2rem" height="2rem" className=" text-red-100 absolute top-2 right-5 cursor-pointer shadow-lg"
-                    onClick={shrink} />}
-
-        {isFolded && <Icon icon={menuUnFoldRight} width="2rem" height="2rem" className=" text-red-100 absolute top-2 right-5 cursor-pointer shadow-lg" 
-            onClick={expand} /> }
-
-    
-    </div>;
-
+export default function FloorplanViewer(props: FloorPlanViewerProps) {
+    return <DynamicFloorplanViewerGame {...props} />;
 }

--- a/src/app/house_layout/FloorplanViewerGame.tsx
+++ b/src/app/house_layout/FloorplanViewerGame.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useMemo } from "react";
+import { Game } from "phaser";
+import { useMeasure, useLatest } from "react-use";
+import { usePathname, useRouter } from "next/navigation";
+import { HouseDef, RoomDef } from "./common";
+import { FloorplanViewerScene } from "./FloorplanViewerScene";
+
+interface FloorPlanViewerGameProps {
+    houseDef: HouseDef;
+    isPanelOpen: boolean;
+    roomDefs: RoomDef[];
+    onPanelVisibilityChange: (open: boolean) => void;
+    className?: string;
+}
+
+export default function FloorplanViewerGame({
+    houseDef,
+    isPanelOpen,
+    roomDefs,
+    onPanelVisibilityChange
+}: FloorPlanViewerGameProps) {
+    
+    const floorplanGame = useRef<Game>(undefined);
+    const floorplanContainer = useRef<HTMLDivElement>(undefined);
+    const [containerMeasure, { width: containerWidth, height: containerHeight }] = useMeasure<HTMLDivElement>();
+
+    const assignRef = useCallback((element: HTMLDivElement) => {
+        containerMeasure(element);
+        floorplanContainer.current = element;
+    }, [containerMeasure]);
+
+    const router = useRouter();
+    const pathname = usePathname();
+
+    const handleRoomClick = useCallback((roomId: string) => {
+        const parts = pathname.split("/");
+        const currentRoom = parts[2];
+        // If clicking a different room, always go to room root
+        if (currentRoom !== roomId) {
+            router.push(`/house_layout/${roomId}`);
+        }
+        // Ensure details panel is visible (non-fullscreen)
+        if (!isPanelOpen) {
+            onPanelVisibilityChange(true);
+        }
+    }, [router, pathname, isPanelOpen, onPanelVisibilityChange]);
+
+    const handleRoomInteractionLatest = useLatest(handleRoomClick);
+
+    // Handle cleanup when component unmounts
+    useEffect(() => {
+        return () => {
+            if (floorplanGame.current) {
+                floorplanGame.current.destroy(true);
+                floorplanGame.current = undefined;
+                gameCreated.current = false;
+                initialSize.current = null;
+            }
+        };
+    }, []);
+
+    // Track if game has been created to prevent recreation
+    const gameCreated = useRef(false);
+    
+    // Store initial container size to avoid recreation on minor changes
+    const initialSize = useRef<{width: number, height: number} | null>(null);
+
+    // Initialize Phaser game - only once when container is ready
+    useLayoutEffect(() => {
+        if (containerWidth > 0 && containerHeight > 0 && floorplanContainer.current && !gameCreated.current) {
+            
+            initialSize.current = { width: containerWidth, height: containerHeight };
+            
+            floorplanGame.current = new Game({
+                type: Phaser.AUTO,
+                width: containerWidth,
+                height: containerHeight,
+                transparent: true,
+                parent: floorplanContainer.current,
+                scene: [FloorplanViewerScene],
+                scale: {
+                    mode: Phaser.Scale.RESIZE,
+                },
+                physics: {
+                    default: 'arcade',
+                    arcade: {
+                        gravity: { x: 0, y: 0 },
+                        debug: false
+                    }
+                },
+                plugins: {
+                    global: [],
+                    scene: []
+                }
+            });
+
+            gameCreated.current = true;
+
+            // Wait for the scene to be ready, then start it with initial data
+            floorplanGame.current.events.once('ready', () => {
+                const sceneManager = floorplanGame.current!.scene;
+                sceneManager.start('FloorplanViewerScene', { houseDef, roomDefs });
+            });
+
+            // Listen for room click events from the Phaser scene and navigate
+            floorplanGame.current.events.on('roomClicked', (roomId: string) => {
+                handleRoomInteractionLatest.current?.(roomId);
+            });
+        }
+
+        return () => {
+            // Cleanup handled in component unmount effect
+        };
+    }, [containerWidth, containerHeight]); // Need dimensions to create properly
+
+    // Handle container size changes separately - just resize, don't recreate
+    useLayoutEffect(() => {
+        if (floorplanGame.current && containerWidth > 0 && containerHeight > 0) {
+            floorplanGame.current.scale.resize(containerWidth, containerHeight);
+        }
+    }, [containerWidth, containerHeight]);
+
+    // Handle route-based room navigation
+    useEffect(() => {
+        const parts = pathname.split("/");
+        if (parts.length > 2) {
+            const elementId = parts[2];
+            setTimeout(() => {
+                handleRoomInteractionLatest.current?.(decodeURI(elementId));
+            }, 100);
+        }
+    }, [pathname, handleRoomInteractionLatest]);
+
+    return (
+        <div className="relative w-full h-full overflow-hidden" ref={assignRef} />
+    );
+}

--- a/src/app/house_layout/FloorplanViewerScene.ts
+++ b/src/app/house_layout/FloorplanViewerScene.ts
@@ -1,0 +1,153 @@
+import { HouseDef, RoomDef } from "./common";
+import { getHexNumberByName, FloorPlanColor } from "@/ui/colors";
+
+export class FloorplanViewerScene extends Phaser.Scene {
+    private floorplanImage?: Phaser.GameObjects.Image;
+    private houseDef?: HouseDef;
+    private roomDefs: RoomDef[] = [];
+    private roomGraphics: Record<string, Phaser.GameObjects.Graphics> = {};
+    private defaultZoom: number = 1;
+    private defaultCameraX: number = 0;
+    private defaultCameraY: number = 0;
+    private isDragging: boolean = false;
+    private lastPointerX: number = 0;
+    private lastPointerY: number = 0;
+
+    constructor() {
+        super("FloorplanViewerScene");
+    }
+
+    init(data?: { houseDef: HouseDef, roomDefs: RoomDef[] }) {
+        if (data) {
+            this.houseDef = data.houseDef;
+            this.roomDefs = data.roomDefs || [];
+        }
+        
+    }
+
+    preload() {
+        if (this.houseDef?.floorplanPicture) {
+            this.load.image('floorplan-background', this.houseDef.floorplanPicture);
+        }
+    }
+
+    create() {
+        if (!this.houseDef) {
+            return;
+        }
+
+        const { width, height } = this.scale;
+        
+        // Create background image
+        this.floorplanImage = this.add.image(0, 0, 'floorplan-background');
+        this.floorplanImage.setOrigin(0.5, 0.5);
+        
+        // Calculate zoom to fit image nicely in view
+        const scaleX = (width * 0.8) / this.floorplanImage.width;
+        const scaleY = (height * 0.8) / this.floorplanImage.height;
+        this.defaultZoom = Math.min(scaleX, scaleY);
+        
+        this.cameras.main.setZoom(this.defaultZoom);
+        this.cameras.main.centerOn(0, 0);
+        
+        this.defaultCameraX = this.cameras.main.scrollX;
+        this.defaultCameraY = this.cameras.main.scrollY;
+
+        // Add camera controls
+        this.setupCameraControls();
+
+        // Draw rooms as polygons (gray fill/stroke)
+        this.drawRooms();
+    }
+
+    private setupCameraControls() {
+        // Mouse/touch dragging
+        this.input.on('pointerdown', (pointer: any) => {
+            this.isDragging = true;
+            this.lastPointerX = pointer.x;
+            this.lastPointerY = pointer.y;
+        });
+
+        this.input.on('pointermove', (pointer: any) => {
+            if (this.isDragging) {
+                const deltaX = pointer.x - this.lastPointerX;
+                const deltaY = pointer.y - this.lastPointerY;
+                
+                this.cameras.main.scrollX -= deltaX / this.cameras.main.zoom;
+                this.cameras.main.scrollY -= deltaY / this.cameras.main.zoom;
+                
+                this.lastPointerX = pointer.x;
+                this.lastPointerY = pointer.y;
+            }
+        });
+
+        this.input.on('pointerup', () => {
+            this.isDragging = false;
+        });
+
+        // Mouse wheel zoom
+        this.input.on('wheel', (pointer: any, gameObjects: any[], deltaX: number, deltaY: number) => {
+            const zoomFactor = deltaY > 0 ? 0.9 : 1.1;
+            const newZoom = Phaser.Math.Clamp(this.cameras.main.zoom * zoomFactor, 0.1, 3);
+            
+            this.cameras.main.setZoom(newZoom);
+        });
+    }
+
+    resetView() {
+        this.cameras.main.setZoom(this.defaultZoom);
+        this.cameras.main.setScroll(this.defaultCameraX, this.defaultCameraY);
+    }
+
+    private drawRooms() {
+        // Clear existing graphics if redrawing
+        Object.values(this.roomGraphics).forEach(g => g.destroy());
+        this.roomGraphics = {};
+
+        for (const room of this.roomDefs) {
+            if (!room.vertices || room.vertices.length < 3) continue;
+
+            const g = this.add.graphics();
+
+            // Determine color from room metadata (Tailwind-like name) or default gray
+            const colorName = (room.color || "gray-500") as FloorPlanColor as any;
+            const hexNumber = getHexNumberByName(colorName);
+
+            // Helper to render with optional highlight
+            const render = (highlight: boolean) => {
+                g.clear();
+                g.fillStyle(hexNumber, highlight ? 0.35 : 0.2);
+                g.lineStyle(highlight ? 3 : 2, hexNumber, 1);
+                g.fillPoints(room.vertices as unknown as Phaser.Types.Math.Vector2Like[], true);
+                g.strokePoints(room.vertices as unknown as Phaser.Types.Math.Vector2Like[], true);
+            };
+
+            render(false);
+
+            // Make the polygon interactive for potential future interactions
+            const phaserPoints = room.vertices.map(v => new Phaser.Geom.Point(v.x, v.y));
+            const poly = new Phaser.Geom.Polygon(phaserPoints);
+            g.setInteractive(poly, Phaser.Geom.Polygon.Contains);
+
+            // Log interactivity on click and notify app for navigation
+            g.on('pointerdown', () => {
+                // eslint-disable-next-line no-console
+                this.game.events.emit('roomClicked', room.id);
+            });
+
+            // Hover effects: highlight and pointer cursor
+            g.on('pointerover', () => {
+                this.input.setDefaultCursor('pointer');
+                g.setDepth(10);
+                render(true);
+            });
+            g.on('pointerout', () => {
+                this.input.setDefaultCursor('default');
+                g.setDepth(0);
+                render(false);
+            });
+
+            this.roomGraphics[room.id] = g;
+        }
+    }
+}

--- a/src/app/house_layout/LayoutClient.tsx
+++ b/src/app/house_layout/LayoutClient.tsx
@@ -1,8 +1,12 @@
 "use client";
 import FloorplanViewer from "./FloorplanViewer";
-import { Suspense, useState } from "react";
+import { Suspense, useState, useEffect } from "react";
 import { cn } from "@/utils/tailwind";
 import { HouseDef, RoomDef } from "./common";
+import { Icon } from '@iconify-icon/react';
+import menuFoldLeft from '@iconify-icons/line-md/menu-fold-left';
+import menuUnFoldRight from '@iconify-icons/line-md/menu-unfold-right';
+import { usePathname } from "next/navigation";
 
 interface LayoutClientProps {
     houseDef: HouseDef;
@@ -11,18 +15,47 @@ interface LayoutClientProps {
 }
 
 export default function Layout( { houseDef, roomDefs, children }: LayoutClientProps) {
+    const pathname = usePathname();
+    
+    // Automatically open panel when navigating to child routes
+    const shouldShowPanel = pathname !== '/house_layout';
+    const [isPanelOpen, setIsPanelOpen] = useState(shouldShowPanel);
 
-    const [fullScreenView, setFullScreenView] = useState(true);
+    // Update panel state when route changes
+    useEffect(() => {
+        setIsPanelOpen(shouldShowPanel);
+    }, [shouldShowPanel]);
 
-    return <div className={cn("w-full h-lvh grid", {
-        "grid-cols-2": !fullScreenView,
-        "grid-cols-1 grid-rows-1": fullScreenView,
-    })}>
+    return <div className="w-full h-lvh relative overflow-hidden">
         <Suspense>
-            <FloorplanViewer houseDef={houseDef} roomDefs={roomDefs} isFolded={!fullScreenView} 
-                onFold={(isFolded => setFullScreenView(!isFolded))} />
+            <FloorplanViewer
+                houseDef={houseDef}
+                roomDefs={roomDefs}
+                isPanelOpen={isPanelOpen}
+                onPanelVisibilityChange={setIsPanelOpen}
+            />
         </Suspense>
         
-        {!fullScreenView && children}
+        <div className={cn("absolute top-0 right-0 bottom-0 pointer-events-none transition-[width] duration-300", {
+            "w-1/2": isPanelOpen,
+            "w-0": !isPanelOpen
+        })}>
+            {isPanelOpen && (
+                <div className="pointer-events-none">
+                    {children}
+                </div>
+            )}
+            
+            <Icon 
+                icon={isPanelOpen ? menuUnFoldRight : menuFoldLeft} 
+                width="2rem" 
+                height="2rem" 
+                className={cn("text-red-100 absolute top-2 cursor-pointer shadow-lg z-10 pointer-events-auto", {
+                    "left-[-3em]": isPanelOpen,
+                    "right-5": !isPanelOpen
+                })}
+                onClick={() => setIsPanelOpen(!isPanelOpen)} 
+            />
+        </div>
     </div>;
 }

--- a/src/app/house_layout/[room]/LocationsList.tsx
+++ b/src/app/house_layout/[room]/LocationsList.tsx
@@ -64,7 +64,7 @@ export default function LocationsList({ className, locations, roomId }: Location
 
   return (
     <div className={cn("rounded-2xl p-6", className)}>
-      <div className="flex flex-wrap gap-4 justify-start">
+      <div className="flex flex-wrap gap-4 justify-start pointer-events-auto">
         {locations.map((location) => (
           <Tooltip
             key={location.id}

--- a/src/app/house_layout/[room]/[location]/ItemsList.tsx
+++ b/src/app/house_layout/[room]/[location]/ItemsList.tsx
@@ -26,7 +26,7 @@ export default function ItemsList({ className, items = [], locationName = "" }: 
   return (
     <div className={className}>
       <div className="px-2 py-3">
-        <div className="flex flex-wrap gap-4 justify-start">
+        <div className="flex flex-wrap gap-4 justify-start pointer-events-auto">
           {items.map((item) => (
             <Bubble
               key={item.id}

--- a/src/app/house_layout/[room]/layout.tsx
+++ b/src/app/house_layout/[room]/layout.tsx
@@ -32,7 +32,7 @@ export default async function RoomLayout(props: PropsWithChildren<{ params: Prom
   }
 
   return (
-    <div className="room-layout h-screen flex flex-col">
+    <div className="room-layout h-screen flex flex-col pointer-events-none">
       <div className="flex-shrink-0 px-2 pt-2">
         <Card className="hover:scale-100 hover:[&>div]:scale-100 hover:[&>div]:shadow-none">
           <CardHeader className="py-4 items-center text-center">

--- a/src/app/house_layout/common.ts
+++ b/src/app/house_layout/common.ts
@@ -1,3 +1,6 @@
+import { RoomMetadataType } from "@/services/roomService";
+import { room as RoomPrismaType} from "@prisma/client"
+
 export interface HouseDef {
     name: string;
     floorplanPicture: string,
@@ -5,11 +8,4 @@ export interface HouseDef {
     height: number
 }
 
-export interface RoomDef {
-    id: string;
-    name: string;
-    x: number;
-    y: number;
-    w: number;
-    h: number;
-}
+export type RoomDef = RoomMetadataType & Pick<RoomPrismaType, 'id' | 'name'>

--- a/src/app/house_layout/layout.tsx
+++ b/src/app/house_layout/layout.tsx
@@ -2,7 +2,7 @@
 import AuthProtectedComponent from "@/AuthProtectedComponent";
 import LayoutClient from "@/app/house_layout/LayoutClient";
 import { getSession } from "@/auth";
-import { fetchHouseForFamily, fetchRoomsForHouse } from "@/services/roomService";
+import { fetchHouseForFamily, fetchRoomsForHouse, RoomMetadataType } from "@/services/roomService";
 import { redirect  } from "next/navigation";
 import { HouseDef } from "./common";
 import { room as RoomType } from "@prisma/client";
@@ -26,11 +26,12 @@ async function DataLoader({ children }: { children: React.ReactNode }) {
     const rooms = await fetchRoomsForHouse(house.id);
 
     const roomDefs = rooms.map((room: RoomType) => {
-        const {x, y, h, w} = room.metadata as {x: number, y: number, h: number, w: number};
+        const {vertices, color} = room.metadata as unknown as RoomMetadataType;
         return {
             id: room.id,
             name: room.name,
-            x, y, h, w
+            vertices,
+            color
         }
     });
 

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -2,6 +2,8 @@ import prisma from "./db";
 import { getSession } from "@/auth";
 import { room } from "@prisma/client"
 
+
+
 export async function fetchHouseForFamily(familyId: number) {
     try {
         const house = await prisma.house.findFirst({
@@ -24,6 +26,14 @@ export async function fetchRoomsForHouse(houseId: number) {
     } catch (error) {
         throw new Error('Error fetching rooms');
     }
+}
+
+export interface RoomMetadataType {
+    color: string,
+    vertices: Array<{
+        x: number,
+        y: number
+    }>
 }
 
 export async function fetchRoomForFamily(roomId: string, prismaInstance = prisma) : Promise<room | null> {


### PR DESCRIPTION
### TL;DR

Replaced the React-based floorplan viewer with a Phaser-powered interactive map for better performance and user experience.

### What changed?

- Replaced the React Zoom Pan Pinch implementation with a Phaser-based game canvas for the floorplan viewer
- Created new components: `FloorplanViewerGame.tsx` and `FloorplanViewerScene.ts` to handle the Phaser implementation
- Updated the room definition interface to use vertices for polygon-based room shapes instead of simple rectangles
- Modified the layout to use a slide-in panel design instead of the previous grid-based approach
- Added proper pointer events handling to ensure UI elements remain interactive
- Updated the `.gitignore` to exclude the AGENTS.md file (codex CLI depends on this file)


### Preview
https://ibb.co/q3qzNtdC

### How to test?

1. Navigate to the house layout page
2. Verify the floorplan loads correctly with rooms displayed as interactive polygons
3. Test zooming (mouse wheel) and panning (click and drag) functionality
4. Click on rooms to navigate to their details
5. Test the panel toggle button to show/hide the room details panel
6. Verify that clicking on locations and items within rooms works correctly

### Why make this change?

The Phaser-based implementation provides several advantages:
- Better performance for complex floorplan interactions
- More natural zooming and panning behavior
- Support for polygon-based room shapes instead of just rectangles
- Improved visual feedback with hover effects and highlighting
- More responsive UI with the slide-in panel design
- Cleaner separation between the visualization and UI components