### PR TITLE
Implement camera centering based on folded state with smooth transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ design/claude/*
 design/codex/*
 AGENTS.md
 
+AGENTS.md
+
 public/assets
 scripts/symbollink.js
 .vscode/**/*

--- a/src/app/house_layout/FloorplanViewerScene.ts
+++ b/src/app/house_layout/FloorplanViewerScene.ts
@@ -1,4 +1,4 @@
-import { HouseDef, RoomDef } from "./common";
+import { HouseDef, RoomDef, ViewerMode } from "./common";
 import { getHexNumberByName, FloorPlanColor } from "@/ui/colors";
 
 export class FloorplanViewerScene extends Phaser.Scene {
@@ -6,21 +6,22 @@ export class FloorplanViewerScene extends Phaser.Scene {
     private houseDef?: HouseDef;
     private roomDefs: RoomDef[] = [];
     private roomGraphics: Record<string, Phaser.GameObjects.Graphics> = {};
-    private defaultZoom: number = 1;
-    private defaultCameraX: number = 0;
-    private defaultCameraY: number = 0;
     private isDragging: boolean = false;
+    private pinHandler?: (mode: ViewerMode, element?: unknown) => void;
     private lastPointerX: number = 0;
     private lastPointerY: number = 0;
+    private currentMode: ViewerMode = ViewerMode.Fullscreen;
+    private resizeHandler?: () => void;
 
     constructor() {
         super("FloorplanViewerScene");
     }
 
-    init(data?: { houseDef: HouseDef, roomDefs: RoomDef[] }) {
+    init(data?: { houseDef: HouseDef, roomDefs: RoomDef[], mode: ViewerMode }) {
         if (data) {
             this.houseDef = data.houseDef;
             this.roomDefs = data.roomDefs || [];
+            this.currentMode = data.mode;
         }
         
     }
@@ -36,28 +37,45 @@ export class FloorplanViewerScene extends Phaser.Scene {
             return;
         }
 
-        const { width, height } = this.scale;
-        
-        // Create background image
+        // Create background image, centered at world (0,0).
         this.floorplanImage = this.add.image(0, 0, 'floorplan-background');
         this.floorplanImage.setOrigin(0.5, 0.5);
-        
-        // Calculate zoom to fit image nicely in view
-        const scaleX = (width * 0.8) / this.floorplanImage.width;
-        const scaleY = (height * 0.8) / this.floorplanImage.height;
-        this.defaultZoom = Math.min(scaleX, scaleY);
-        
-        this.cameras.main.setZoom(this.defaultZoom);
-        this.cameras.main.centerOn(0, 0);
-        
-        this.defaultCameraX = this.cameras.main.scrollX;
-        this.defaultCameraY = this.cameras.main.scrollY;
+
+        // Initial fit using current mode (fullscreen or folded).
+        // Use animate: false so the very first frame is correctly centered.
+        this.resetView(this.currentMode, { animate: false });
 
         // Add camera controls
         this.setupCameraControls();
 
         // Draw rooms as polygons (gray fill/stroke)
         this.drawRooms();
+
+        // Listen for pin events from app
+        this.pinHandler = (mode: ViewerMode, _element?: unknown) => {
+            if (!this.floorplanImage) return;
+            this.currentMode = mode;
+            this.resetView(mode);
+        };
+        this.game.events.on('pin', this.pinHandler);
+
+        // Recenter on Phaser scale resize
+        this.resizeHandler = () => {
+            this.resetView(this.currentMode);
+        };
+        this.scale.on('resize', this.resizeHandler);
+
+        // Remove listeners on shutdown to prevent leaks
+        this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+            if (this.pinHandler) {
+                this.game.events.off('pin', this.pinHandler);
+                this.pinHandler = undefined;
+            }
+            if (this.resizeHandler) {
+                this.scale.off('resize', this.resizeHandler);
+                this.resizeHandler = undefined;
+            }
+        });
     }
 
     private setupCameraControls() {
@@ -94,10 +112,61 @@ export class FloorplanViewerScene extends Phaser.Scene {
         });
     }
 
-    resetView() {
-        this.cameras.main.setZoom(this.defaultZoom);
-        this.cameras.main.setScroll(this.defaultCameraX, this.defaultCameraY);
+    // Compute desired zoom and scroll to fit image in a given viewport box
+    private computeViewportZoom(params: { fitWidth: number; fitHeight: number; marginFactor?: number; }) {
+        if (!this.floorplanImage) return null;
+        const { fitWidth, fitHeight, marginFactor = 0.8 } = params;
+        const imgW = this.floorplanImage.width;
+        const imgH = this.floorplanImage.height;
+        const zoom = Math.min((fitWidth * marginFactor) / imgW, (fitHeight * marginFactor) / imgH);
+        return { zoom };
     }
+
+    // Public: Center the floorplan based on the given mode.
+    // Screen-space model (no speculative algebra):
+    // 1) Treat camera width/height as viewport pixels (screen-space); zoom does not change these.
+    // 2) To place world(0,0) at a desired screen point S=(x,y) with no scaling, the camera center should move to
+    //    C = (cam.width/2 - x, cam.height/2 - y).
+    // 3) When zoomed by z, camera coordinates are scaled, so divide the whole center shift by z:
+    //    C = ((cam.width/2 - x)/z, (cam.height/2 - y)/z).
+    // 4) For mode → pick S: fullscreen S=(cam.width/2, cam.height/2); folded S=(cam.width/4, cam.height/2).
+    // 5) Compute target zoom z from the fit (~80% of available width/height; folded uses width/2) and pan to C.
+    resetView(mode: ViewerMode = ViewerMode.Fullscreen, opts?: { animate?: boolean; duration?: number; ease?: string }) {
+        const cam = this.cameras.main;
+        const gameW = this.scale.width;
+        const gameH = this.scale.height;
+        const fitWidth = (mode === ViewerMode.Folded) ? gameW / 2 : gameW;
+        const fitHeight = gameH;
+        const fit = this.computeViewportZoom({ fitWidth, fitHeight });
+        if (!fit) return;
+
+        const animate = opts?.animate ?? true;
+        const duration = opts?.duration ?? 300;
+        const ease = opts?.ease ?? 'Sine.easeOut';
+
+        // Desired on-screen pixel for world (0,0): center (fullscreen) or left-half center (folded)
+        const targetScreenX = (mode === ViewerMode.Folded) ? gameW / 4 : gameW / 2;
+        const targetScreenY = gameH / 2;
+
+        const targetZoom = fit.zoom;
+        // Why divide by zoom here (not multiply):
+        // - We compute a screen-space center shift Δs = (cam.width/2 - targetScreenX, cam.height/2 - targetScreenY).
+        // - Zoom is applied after pan, so Δscreen = Δcamera × zoom.
+        // - To get the camera-space shift, divide by zoom: Δcamera = Δs / zoom.
+        // - Thus the camera center to pan to is:
+        const worldCenterX = (cam.width / 2 - targetScreenX) / targetZoom;
+        const worldCenterY = (cam.height / 2 - targetScreenY) / targetZoom;
+
+        if (animate) {
+            cam.zoomTo(targetZoom, duration, ease, true);
+            cam.pan(worldCenterX, worldCenterY, duration, ease, true);
+        } else {
+            cam.setZoom(targetZoom);
+            cam.centerOn(worldCenterX, worldCenterY);
+        }
+    }
+
+    // (All debug overlay and crosshair helpers removed for production cleanliness)
 
     private drawRooms() {
         // Clear existing graphics if redrawing
@@ -129,9 +198,8 @@ export class FloorplanViewerScene extends Phaser.Scene {
             const poly = new Phaser.Geom.Polygon(phaserPoints);
             g.setInteractive(poly, Phaser.Geom.Polygon.Contains);
 
-            // Log interactivity on click and notify app for navigation
+            // Notify app for navigation on click
             g.on('pointerdown', () => {
-                // eslint-disable-next-line no-console
                 this.game.events.emit('roomClicked', room.id);
             });
 

--- a/src/app/house_layout/common.ts
+++ b/src/app/house_layout/common.ts
@@ -9,3 +9,8 @@ export interface HouseDef {
 }
 
 export type RoomDef = RoomMetadataType & Pick<RoomPrismaType, 'id' | 'name'>
+
+export enum ViewerMode {
+    Fullscreen = 'fullscreen',
+    Folded = 'folded',
+}


### PR DESCRIPTION
### TL;DR

Improved the floorplan viewer to dynamically centers itself based on panel folding/fullscreen state.

### What changed?

- Added a `ViewerMode` enum to track whether the floorplan is in fullscreen or folded (panel open) mode
- Implemented a responsive camera system that properly centers and scales the floorplan based on the current mode
- Added event listeners to handle panel state changes and window resizing
- Removed hardcoded positioning in favor of dynamic viewport calculations
- Added proper cleanup of event listeners to prevent memory leaks

### Preview
https://ibb.co/C3b1g9QH

### How to test?

1. Open the house layout page and verify the floorplan is properly centered
2. Click on a room to open its details panel and confirm the floorplan smoothly animates to the folded position
3. Close the panel and verify the floorplan returns to fullscreen mode
4. Resize the browser window and check that the floorplan maintains proper scaling and positioning
5. Navigate between rooms and ensure the floorplan maintains its position relative to the panel state

### Why make this change?

This change creates a more polished user experience by ensuring the floorplan always displays optimally regardless of the panel state or viewport size. The improved camera system provides smoother transitions and better utilization of screen space.