### PR TITLE
Also zoom to a selected room when a room is clicked

### DIFF
--- a/src/app/house_layout/LayoutClient.tsx
+++ b/src/app/house_layout/LayoutClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 import FloorplanViewer from "./FloorplanViewer";
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useState, useEffect, useCallback } from "react";
 import { cn } from "@/utils/tailwind";
 import { HouseDef, RoomDef } from "./common";
 import { Icon } from '@iconify-icon/react';
@@ -8,6 +8,17 @@ import menuFoldLeft from '@iconify-icons/line-md/menu-fold-left';
 import menuUnFoldRight from '@iconify-icons/line-md/menu-unfold-right';
 import { usePathname } from "next/navigation";
 
+
+const stopAll = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // Best-effort: stop native propagation so canvas listeners don't receive it
+    // @ts-ignore
+    if (e.nativeEvent?.stopImmediatePropagation) {
+        // @ts-ignore
+        e.nativeEvent.stopImmediatePropagation();
+    }
+};
 interface LayoutClientProps {
     houseDef: HouseDef;
     roomDefs: RoomDef[];
@@ -25,6 +36,8 @@ export default function Layout( { houseDef, roomDefs, children }: LayoutClientPr
     useEffect(() => {
         setIsPanelOpen(shouldShowPanel);
     }, [shouldShowPanel]);
+
+    
 
     return <div className="w-full h-lvh relative overflow-hidden">
         <Suspense>
@@ -46,16 +59,23 @@ export default function Layout( { houseDef, roomDefs, children }: LayoutClientPr
                 </div>
             )}
             
-            <Icon 
-                icon={isPanelOpen ? menuUnFoldRight : menuFoldLeft} 
-                width="2rem" 
-                height="2rem" 
-                className={cn("text-red-100 absolute top-2 cursor-pointer shadow-lg z-10 pointer-events-auto", {
-                    "left-[-3em]": isPanelOpen,
-                    "right-5": !isPanelOpen
-                })}
-                onClick={() => setIsPanelOpen(!isPanelOpen)} 
-            />
+            <div
+                className={cn("text-red-100 absolute top-2 z-10 pointer-events-auto p-4", {
+                "left-[-3em]": isPanelOpen,
+                "right-5": !isPanelOpen
+            })}
+                onPointerDownCapture={stopAll}
+                onPointerUpCapture={stopAll}
+            >
+                <Icon 
+                    icon={isPanelOpen ? menuUnFoldRight : menuFoldLeft} 
+                    className={"cursor-pointer shadow-lg w-8 h-8"}
+                    width={'2em'}
+                    height={'2em'}
+                    onClick={(e) => { stopAll(e); setIsPanelOpen(!isPanelOpen); }}
+                   
+                />
+            </div>
         </div>
     </div>;
 }


### PR DESCRIPTION
### TL;DR

Improved room selection and navigation in the floorplan viewer by adding the ability to zoom to specific rooms.

### What changed?

- Added room selection state tracking with `selectedRoomId` in `FloorplanViewerGame`
- Enhanced the `resetView` method in `FloorplanViewerScene` to support zooming to specific rooms
- Added `getRoomBox` helper method to calculate room boundaries for proper zooming
- Improved URL-based room navigation to properly select and zoom to rooms
- Fixed event propagation issues with the panel toggle button
- Replaced `useEffect` with `useMount` for initial room selection to prevent unnecessary re-renders

### Preview
https://ibb.co/HTvs15wD

### How to test?

1. Navigate to a room URL (e.g., `/house/room-id`) and verify the view automatically zooms to that room
2. Click on different rooms in the floorplan and verify the view smoothly transitions to each selected room
3. Toggle between folded and fullscreen modes to ensure the selected room remains properly centered
4. Test the panel toggle button to ensure it works correctly without triggering other interactions

### Why make this change?

This enhancement improves the user experience by providing better visual context when navigating between rooms. When a user selects a room (either via URL or by clicking), the view now properly zooms and centers on that room, making it easier to understand the spatial relationship between rooms in the house layout. The implementation also fixes event handling issues and optimizes the rendering process.