### PR TITLE
house_layout: route-driven panel; derive viewer mode from selection

### DIFF
--- a/src/app/house_layout/FloorplanViewer.tsx
+++ b/src/app/house_layout/FloorplanViewer.tsx
@@ -7,7 +7,6 @@ interface FloorPlanViewerProps {
     houseDef: HouseDef;
     isPanelOpen: boolean;
     roomDefs: RoomDef[];
-    onPanelVisibilityChange: (open: boolean) => void;
     className?: string;
 }
 

--- a/src/app/house_layout/LayoutClient.tsx
+++ b/src/app/house_layout/LayoutClient.tsx
@@ -6,7 +6,7 @@ import { HouseDef, RoomDef } from "./common";
 import { Icon } from '@iconify-icon/react';
 import menuFoldLeft from '@iconify-icons/line-md/menu-fold-left';
 import menuUnFoldRight from '@iconify-icons/line-md/menu-unfold-right';
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 
 const stopAll = (e: React.SyntheticEvent) => {
@@ -27,6 +27,7 @@ interface LayoutClientProps {
 
 export default function Layout( { houseDef, roomDefs, children }: LayoutClientProps) {
     const pathname = usePathname();
+    const router = useRouter();
     
     // Automatically open panel when navigating to child routes
     const shouldShowPanel = pathname !== '/house_layout';
@@ -36,7 +37,6 @@ export default function Layout( { houseDef, roomDefs, children }: LayoutClientPr
     useEffect(() => {
         setIsPanelOpen(shouldShowPanel);
     }, [shouldShowPanel]);
-
     
 
     return <div className="w-full h-lvh relative overflow-hidden">
@@ -45,7 +45,6 @@ export default function Layout( { houseDef, roomDefs, children }: LayoutClientPr
                 houseDef={houseDef}
                 roomDefs={roomDefs}
                 isPanelOpen={isPanelOpen}
-                onPanelVisibilityChange={setIsPanelOpen}
             />
         </Suspense>
         
@@ -72,7 +71,15 @@ export default function Layout( { houseDef, roomDefs, children }: LayoutClientPr
                     className={"cursor-pointer shadow-lg w-8 h-8"}
                     width={'2em'}
                     height={'2em'}
-                    onClick={(e) => { stopAll(e); setIsPanelOpen(!isPanelOpen); }}
+                    onClick={(e) => {
+                        stopAll(e);
+                        // Folded state should only be entered via room click (route change).
+                        // When closing the panel, navigate back to /house_layout without full refresh.
+                        if (isPanelOpen) {
+                            router.replace('/house_layout');
+                        }
+                        // If panel is closed, do nothing here; opening occurs when a room is clicked.
+                    }}
                    
                 />
             </div>


### PR DESCRIPTION
### TL;DR

Improved the floorplan viewer navigation by making panel visibility state driven by URL routing instead of a separate state variable.

### What changed?

- Changed the panel toggle button to navigate to the base route when closing the panel
- Simplified the mode determination logic to be based on whether a room is selected. Removed the `onPanelVisibilityChange` prop from `FloorplanViewer` and `FloorplanViewerGame` components
- Updated the room selection mechanism to sync with URL changes

### Preview
https://ibb.co/Kx76CnCH

### How to test?

1. Navigate to `/house_layout` to see the fullscreen floorplan
2. Click on a room to verify the panel opens and URL updates to `/house_layout/{roomId}`
3. Click the panel close button to verify it returns to the base route `/house_layout`
4. Directly navigate to a room URL to verify the correct room is selected and panel is open
5. Verify that browser back/forward navigation correctly updates both the selected room and panel state

### Why make this change?

This change improves the user experience by:
- Making the UI state more consistent
- Removed the useless floating panel when no room is selected.
- Ensuring browser history navigation works correctly with the panel state
