### PR TITLE
Fixes some style issues 

### DIFF
--- a/src/app/house_layout/[room]/LinkWithReport.tsx
+++ b/src/app/house_layout/[room]/LinkWithReport.tsx
@@ -14,7 +14,7 @@ export default function LinkWithReport({ roomId, locationId, locationName} : Lin
     const { setSelectedLocation} = useContext(LocationSelectionContext);
 
     return (
-        <Link className="py-2 px-4 text-gray-900" href={`/house_layout/${roomId}/${locationId.replace(`${roomId}_`, '')}`}
+        <Link className="py-2 px-4 text-gray-900 wrap-anywhere" href={`/house_layout/${roomId}/${locationId.replace(`${roomId}_`, '')}`}
             onClick={() => setSelectedLocation(locationName)}>
             {locationId}
         </Link>

--- a/src/app/house_layout/[room]/LocationsList.tsx
+++ b/src/app/house_layout/[room]/LocationsList.tsx
@@ -64,7 +64,7 @@ export default function LocationsList({ className, locations, roomId }: Location
 
   return (
     <div className={cn("rounded-2xl p-6", className)}>
-      <div className="flex flex-wrap gap-4 justify-start pointer-events-auto">
+      <div className="grid grid-cols-3 gap-4 pointer-events-auto">
         {locations.map((location) => (
           <Tooltip
             key={location.id}

--- a/src/app/house_layout/[room]/[location]/ItemsList.tsx
+++ b/src/app/house_layout/[room]/[location]/ItemsList.tsx
@@ -1,4 +1,5 @@
 import { Bubble } from "@/ui/components/bubble";
+import { cn } from "@/utils/tailwind";
 
 interface ItemsListProps {
     items?: { id: number; name: string; quantity: number | null; inotherobject: boolean | null; otherobjectid: number | null }[];
@@ -12,50 +13,46 @@ export default function ItemsList({ className, items = [], locationName = "" }: 
   if (!hasItems) {
     return (
       <div className={className}>
-        <div className="px-2 py-3">
-          <div className="text-center py-8">
-            <Bubble variant="default" className="inline-block">
-              <p className="text-gray-600 text-lg">No item found for this location.</p>
-            </Bubble>
-          </div>
+        <div className="text-center py-8">
+          <Bubble variant="default" className="inline-block">
+            <p className="text-gray-600 text-lg">No item found for this location.</p>
+          </Bubble>
         </div>
       </div>
     );
   }
 
   return (
-    <div className={className}>
-      <div className="px-2 py-3">
-        <div className="flex flex-wrap gap-4 justify-start pointer-events-auto">
-          {items.map((item) => (
-            <Bubble
-              key={item.id}
-              variant="default"
-              size="sm"
-              className="min-w-[220px] !bg-pink-400/20 !border-pink-300/50"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="flex-1 min-w-0">
-                  <h3 className="font-semibold text-gray-800 text-lg mb-1 truncate">{item.name}</h3>
-                  <div className="text-base text-gray-600 flex items-center gap-2">
-                    <span className="opacity-70">ID: {item.id}</span>
-                    {item.otherobjectid !== null && (
-                      <span className="opacity-70">Ref: {item.otherobjectid}</span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex flex-col items-end gap-1">
-                  {item.quantity !== null && (
-                    <span className="bg-white/60 text-gray-800 px-2 py-0.5 rounded text-base font-semibold">x{item.quantity}</span>
-                  )}
-                  {item.inotherobject && (
-                    <span className="text-sm px-2 py-0.5 rounded-full bg-pink-500/20 text-gray-600 border border-pink-400/40">In another object</span>
+    <div className={cn("px-5 py-3", className)}>
+      <div className="grid grid-cols-3 gap-4 pointer-events-auto">
+        {items.map((item) => (
+          <Bubble
+            key={item.id}
+            variant="default"
+            size="sm"
+            className="min-w-[220px] !bg-pink-400/20 !border-pink-300/50"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <h3 className="font-semibold text-gray-800 text-lg mb-1 truncate">{item.name}</h3>
+                <div className="text-base text-gray-600 flex items-center gap-2">
+                  <span className="opacity-70">ID: {item.id}</span>
+                  {item.otherobjectid !== null && (
+                    <span className="opacity-70">Ref: {item.otherobjectid}</span>
                   )}
                 </div>
               </div>
-            </Bubble>
-          ))}
-        </div>
+              <div className="flex flex-col items-end gap-1">
+                {item.quantity !== null && (
+                  <span className="bg-white/60 text-gray-800 px-2 py-0.5 rounded text-base font-semibold">x{item.quantity}</span>
+                )}
+                {item.inotherobject && (
+                  <span className="text-sm px-2 py-0.5 rounded-full bg-pink-500/20 text-gray-600 border border-pink-400/40">In another object</span>
+                )}
+              </div>
+            </div>
+          </Bubble>
+        ))}
       </div>
     </div>
   );

--- a/src/app/house_layout/[room]/[location]/layout.tsx
+++ b/src/app/house_layout/[room]/[location]/layout.tsx
@@ -19,7 +19,7 @@ export default async function LocationLayout(
         </Card>
       </div>
 
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 w-full overflow-auto">
         {children}
       </div>
     </div>

--- a/src/app/house_layout/[room]/layout.tsx
+++ b/src/app/house_layout/[room]/layout.tsx
@@ -44,13 +44,13 @@ export default async function RoomLayout(props: PropsWithChildren<{ params: Prom
       </div>
       <div className="flex-1 flex flex-col">
         <LocationSelectionContextProvider>
-          <div className="h-1/2 overflow-auto">
+          <div className="h-1/2 overflow-x-hidden overflow-y-auto">
             <Suspense fallback={<LoadingCard label="Loading locations…" />}>
               <LocationsPanel roomId={roomId} />
             </Suspense>
           </div>
         </LocationSelectionContextProvider>
-        <div className="h-1/2 overflow-auto">
+        <div className="h-1/2 overflow-visible">
           {children}
         </div>
       </div>

--- a/src/ui/components/bubble.tsx
+++ b/src/ui/components/bubble.tsx
@@ -7,7 +7,7 @@ const bubbleVariants = cva(
   [
     "relative rounded-3xl overflow-hidden transition-all duration-300",
     "hover:scale-[1.02]",
-    "backdrop-blur-xs"
+    "backdrop-blur-xs z-10"
   ],
   {
     variants: {
@@ -61,7 +61,7 @@ const Bubble = React.forwardRef<HTMLDivElement, BubbleProps>(
     return (
       <div className="relative group">
         {/* Grounded shadow directly under bubble (tighter area) */}
-        <div className="absolute -z-10 left-1/2 bottom-3 h-4 w-[70%] -translate-x-1/2 rounded-full bg-shadow/60 blur-md opacity-80 transition-all duration-300 ease-out group-hover:bottom-2 group-hover:blur-lg group-hover:opacity-90" />
+        <div className="absolute z-[1] left-1/2 bottom-3 h-4 w-[70%] -translate-x-1/2 rounded-full bg-shadow/60 blur-md opacity-80 transition-all duration-300 ease-out group-hover:bottom-2 group-hover:blur-lg group-hover:opacity-90" />
         
         {/* Main bubble container */}
         <div
@@ -119,7 +119,7 @@ const Bubble = React.forwardRef<HTMLDivElement, BubbleProps>(
           />
           
           {/* Content with proper text styling for glass effect */}
-          <div className="relative z-10 text-shadow">
+          <div className="relative z-[11] text-shadow">
             {children}
           </div>
         </div>

--- a/src/ui/components/card.tsx
+++ b/src/ui/components/card.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/utils/tailwind"
 
 const cardVariants = cva(
   [
-    "rounded-3xl border-4 border-border text-text-main overflow-hidden transition-all duration-200",
+    "rounded-3xl border-4 border-border text-text-main overflow-hidden transition-all duration-200 relative z-10",
     "hover:scale-[1.02]"
   ],
   {
@@ -48,7 +48,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
         {...props}
       />
       {/* Floating shadow */}
-      <div className="absolute inset-0 -z-10 bg-shadow/60 rounded-3xl blur-[6px] translate-y-2 scale-x-110 origin-bottom group-hover:translate-y-3 group-hover:scale-x-115 group-hover:blur-[10px] group-hover:opacity-80 transition-all duration-200 ease-out" />
+      <div className="absolute inset-y-0 -inset-x-2 z-[1] bg-shadow/60 rounded-3xl blur-[6px] translate-y-2 origin-bottom group-hover:translate-y-3 group-hover:-inset-x-4 group-hover:blur-[10px] group-hover:opacity-80 transition-all duration-200 ease-out" />
     </div>
   )
 )

--- a/src/ui/components/tooltip.tsx
+++ b/src/ui/components/tooltip.tsx
@@ -42,7 +42,7 @@ export default function Tooltip({
       {children}
       <div
         className={cn(
-          "absolute opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-50",
+          "absolute opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none z-500",
           positionClasses[position],
           contentClassName
         )}


### PR DESCRIPTION
### TL;DR

Improved UI display on the `house_layout` page

### What changed?

- Changed `LocationsList` from flex-wrap to a 3-column grid layout
- Updated `ItemsList` to use the same 3-column grid layout for consistency
- Address long link text in the `LinkWithReport` component
- Fixed z-index issues in `Bubble` and `Card` components to prevent overlap problems, so the Phaser scene will properly display under shadows of the Cards.
- Fix the overly wide shadows for the Card component.


### Preview

<img width="3825" height="1944" alt="image" src="https://github.com/user-attachments/assets/68bad33e-f8b8-473f-bbe5-358f2a235c9c" />

### How to test?

1. Navigate to the house layout pages with multiple locations and items
2. Verify that locations and items display in a clean 3-column grid
3. Check that long location names wrap properly
4. Ensure the Card's shadow is drawn over the Phaser scene
