### PR TITLE
floorplan: handle drag state on pointer events

### DIFF
--- a/src/app/house_layout/FloorplanViewerScene.ts
+++ b/src/app/house_layout/FloorplanViewerScene.ts
@@ -108,6 +108,14 @@ export class FloorplanViewerScene extends Phaser.Scene {
             this.isDragging = false;
         });
 
+        this.input.on('pointerupoutside', () => {
+            this.isDragging = false;
+        });
+
+        this.input.on(Phaser.Input.Events.GAME_OUT, () => {
+            this.isDragging = false;
+        });
+
         // Mouse wheel zoom
         this.input.on('wheel', (pointer: any, gameObjects: any[], deltaX: number, deltaY: number) => {
             const zoomFactor = deltaY > 0 ? 0.9 : 1.1;


### PR DESCRIPTION
# PR: Fix stuck camera drag when pointer leaves canvas

## Problem
- Drag-to-pan relied only on `pointerup` to stop the camera movement.
- When the cursor crossed into the React drawer overlay, the release event never reached Phaser, leaving `isDragging` stuck `true`.
- Returning the cursor to the canvas continued to pan the scene even though the mouse button was no longer pressed.

## Solution
- Hook Phaser's `pointerupoutside` and `GAME_OUT` events alongside the existing `pointerup` handler.
- Each of these events now clears the `isDragging` flag, so any release outside the canvas or a pointer leaving the game surface stops the drag immediately.

## Validation
- Manually drag the floorplan, move the cursor over the React drawer, release, and move back onto the canvas.
- Confirm the camera no longer continues panning once the pointer is released.