### PR TITLE
dynamically output image at proper size and cache them.

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,12 @@
 const nextConfig = {
   reactStrictMode: false,
   output: "standalone",
+  images: {
+    formats: ["image/avif", "image/webp"],
+    deviceSizes: [32, 48, 64, 96, 128, 256],
+    imageSizes: [32, 48, 64, 96, 128, 256],
+    minimumCacheTTL: 2592000,
+  },
   turbopack: {
     rules: {
       "*.frag": {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,8 +4,9 @@ const nextConfig = {
   output: "standalone",
   images: {
     formats: ["image/avif", "image/webp"],
-    deviceSizes: [32, 48, 64, 96, 128, 256],
-    imageSizes: [32, 48, 64, 96, 128, 256],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048],
+    imageSizes: [32, 48, 64, 96, 128, 256, 512, 1024],
+    qualities: [33, 50, 75, 100],
     minimumCacheTTL: 2592000,
   },
   turbopack: {

--- a/src/ui/components/IconImage.tsx
+++ b/src/ui/components/IconImage.tsx
@@ -42,7 +42,7 @@ const IconImage = ({
       width={actualSize}
       height={actualSize}
       className="object-contain focus-visible:outline-none"
-      unoptimized
+      sizes="(max-width: 768px) 64px, 256px"
     />
   );
 };

--- a/src/ui/components/IconImage.tsx
+++ b/src/ui/components/IconImage.tsx
@@ -42,7 +42,8 @@ const IconImage = ({
       width={actualSize}
       height={actualSize}
       className="object-contain focus-visible:outline-none"
-      sizes="(max-width: 768px) 64px, 256px"
+      sizes={`${actualSize}px`}
+      quality="100"
     />
   );
 };


### PR DESCRIPTION
### TL;DR

Enable Next.js image optimization for icon images with AVIF/WebP support and long-term caching.

### What changed?

- Configured Next.js image optimization with AVIF and WebP format support, restricted device/image size breakpoints suited for icons, and a 30-day minimum cache TTL.
- Replaced `unoptimized` on the `IconImage` component with a `sizes` attribute, allowing Next.js to serve appropriately sized, optimized images based on viewport width.

### How to test?

1. Run the application and navigate to a page that renders icon images.
2. Inspect network requests and confirm that images are served in AVIF or WebP format.
3. Verify that the correct image size is requested based on the viewport (64px on mobile, 256px on larger screens).
4. Check response headers to confirm cache TTL is set to 30 days.

### Why make this change?

Previously, icon images were served unoptimized, bypassing Next.js's built-in image pipeline. Enabling optimization reduces bandwidth usage by serving modern image formats and appropriately sized images, while the extended cache TTL reduces redundant image processing for assets that rarely change.