### PR TITLE
feat: add Search Bar component and showcase page

### DIFF
--- a/src/app/search/components/MarqueeTooltipOverlay.tsx
+++ b/src/app/search/components/MarqueeTooltipOverlay.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Card } from "@/ui/components/Card";
-import { CardArrow } from "@/ui/components/CardArrow";
+import { FloatingCardWithArrow } from "@/ui/components/FloatingCardWithArrow";
 
 type MarqueeTooltipDetail = {
   label: string;
@@ -66,26 +65,16 @@ export function MarqueeTooltipOverlay({ zoom }: MarqueeTooltipOverlayProps) {
           transform: "translate(-50%, calc(-100% - 25px))",
         }}
       >
-        <div className="relative group tooltip-card-content">
-          <Card
-            noInnerShadow
-            className="p-4 peer border-3 shadow-intensity-weakened card-content"
-            shadowIntensity="weakened"
-          >
-            <div className="flex flex-col gap-1">
-              <p className="font-hand text-base font-bold leading-tight text-foreground">
-                {detail.label}
-              </p>
-              <p className="font-hand text-sm leading-tight text-foreground-secondary">
-                {locationLabel}
-              </p>
-            </div>
-          </Card>
-          <CardArrow
-            className="absolute left-1/2 top-full z-20 -translate-x-1/2 -translate-y-[10px]"
-            fillColor="var(--color-card-default)"
-          />
-        </div>
+        <FloatingCardWithArrow>
+          <div className="flex flex-col gap-1">
+            <p className="font-hand text-base font-bold leading-tight text-foreground">
+              {detail.label}
+            </p>
+            <p className="font-hand text-sm leading-tight text-foreground-secondary">
+              {locationLabel}
+            </p>
+          </div>
+        </FloatingCardWithArrow>
       </div>
     </div>
   );

--- a/src/app/ui_style/navItems.ts
+++ b/src/app/ui_style/navItems.ts
@@ -48,6 +48,10 @@ export const navItems = [
     "href": "/ui_style/overlay-showcase"
   },
   {
+    "title": "Search Bar",
+    "href": "/ui_style/search-bar"
+  },
+  {
     "title": "Tabs",
     "href": "/ui_style/tabs"
   },

--- a/src/app/ui_style/search-bar/SearchBarShowcaseClient.tsx
+++ b/src/app/ui_style/search-bar/SearchBarShowcaseClient.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { Card } from "@/ui/components/Card";
+import { CardArrow } from "@/ui/components/CardArrow";
+import { SearchBar } from "@/ui/components/SearchBar";
+
+type SearchKind = "default" | "compact";
+
+type PopupState = {
+  kind: "success" | "error";
+  message: string;
+  searchKind: SearchKind;
+} | null;
+
+function SearchHintTooltip({ popup }: { popup: PopupState }) {
+  if (!popup) return null;
+
+  return (
+    <output
+      className="absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-full pointer-events-none"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div className="relative group tooltip-card-content">
+        <Card
+          variant={popup.kind === "success" ? "default" : "primary"}
+          noInnerShadow
+          shadowIntensity="weakened"
+          className="p-4 peer border-3 card-content w-auto min-w-[220px] max-w-sm"
+        >
+          <div className="flex flex-col gap-1">
+            <p
+              className={
+                popup.kind === "success"
+                  ? "font-bold leading-tight text-foreground"
+                  : "font-bold leading-tight text-white"
+              }
+            >
+              {popup.kind === "success" ? "Search Ready" : "Search Needed"}
+            </p>
+            <p
+              className={
+                popup.kind === "success"
+                  ? "leading-tight text-foreground-secondary"
+                  : "leading-tight text-white/80"
+              }
+            >
+              {popup.message}
+            </p>
+          </div>
+        </Card>
+        <CardArrow
+          className="absolute left-1/2 top-full z-20 -translate-x-1/2 -translate-y-[10px]"
+          fillColor={
+            popup.kind === "success"
+              ? "var(--color-card-default)"
+              : "var(--color-primary-accent)"
+          }
+        />
+      </div>
+    </output>
+  );
+}
+
+export default function SearchBarShowcaseClient() {
+  const [popup, setPopup] = useState<PopupState>(null);
+  const popupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const defaultSearchId = useId();
+  const compactSearchId = useId();
+
+  useEffect(() => {
+    return () => {
+      if (popupTimerRef.current) {
+        clearTimeout(popupTimerRef.current);
+      }
+    };
+  }, []);
+
+  const showPopup = (nextPopup: PopupState) => {
+    setPopup(nextPopup);
+    if (popupTimerRef.current) {
+      clearTimeout(popupTimerRef.current);
+    }
+    popupTimerRef.current = setTimeout(() => {
+      setPopup(null);
+      popupTimerRef.current = null;
+    }, 2200);
+  };
+
+  const handleSearch = (
+    searchKind: SearchKind,
+    label: string,
+    value: string,
+  ) => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      showPopup({
+        kind: "error",
+        message: `${label}: please type something first.`,
+        searchKind,
+      });
+      return;
+    }
+
+    showPopup({
+      kind: "success",
+      message: `Fake search for "${trimmed}" is ready.`,
+      searchKind,
+    });
+  };
+
+  return (
+    <div className="w-full max-w-4xl flex flex-col items-center gap-10">
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl font-extrabold">Search Bar</h1>
+        <p className="text-sm text-foreground/70 max-w-xl">
+          This is a UI showcase only. Clicking search shows a fake popup instead
+          of running a real query.
+        </p>
+      </div>
+
+      <section className="w-full flex flex-col items-center gap-10">
+        <div className="relative flex flex-col gap-4 items-center w-full">
+          <label
+            htmlFor={defaultSearchId}
+            className="text-lg font-semibold text-foreground/80"
+          >
+            Default
+          </label>
+          <div className="relative">
+            <SearchHintTooltip
+              popup={popup?.searchKind === "default" ? popup : null}
+            />
+            <SearchBar
+              id={defaultSearchId}
+              placeholder="Default search bar..."
+              onSearch={(value) =>
+                handleSearch("default", "Default search", value)
+              }
+            />
+          </div>
+        </div>
+
+        <div className="relative flex flex-col gap-4 items-center w-full">
+          <label
+            htmlFor={compactSearchId}
+            className="text-lg font-semibold text-foreground/80"
+          >
+            Compact
+          </label>
+          <div className="relative">
+            <SearchHintTooltip
+              popup={popup?.searchKind === "compact" ? popup : null}
+            />
+            <SearchBar
+              id={compactSearchId}
+              variant="compact"
+              placeholder="Compact search bar..."
+              onSearch={(value) =>
+                handleSearch("compact", "Compact search", value)
+              }
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/ui_style/search-bar/SearchBarShowcaseClient.tsx
+++ b/src/app/ui_style/search-bar/SearchBarShowcaseClient.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useId, useRef, useState } from "react";
-import { Card } from "@/ui/components/Card";
-import { CardArrow } from "@/ui/components/CardArrow";
+import { FloatingCardWithArrow } from "@/ui/components/FloatingCardWithArrow";
 import { SearchBar } from "@/ui/components/SearchBar";
+import { cn } from "@/utils/tailwind";
 
 type SearchKind = "default" | "compact";
 
@@ -22,43 +22,31 @@ function SearchHintTooltip({ popup }: { popup: PopupState }) {
       aria-live="polite"
       aria-atomic="true"
     >
-      <div className="relative group tooltip-card-content">
-        <Card
-          variant={popup.kind === "success" ? "default" : "primary"}
-          noInnerShadow
-          shadowIntensity="weakened"
-          className="p-4 peer border-3 card-content w-auto min-w-[220px] max-w-sm"
-        >
-          <div className="flex flex-col gap-1">
-            <p
-              className={
-                popup.kind === "success"
-                  ? "font-bold leading-tight text-foreground"
-                  : "font-bold leading-tight text-white"
-              }
-            >
-              {popup.kind === "success" ? "Search Ready" : "Search Needed"}
-            </p>
-            <p
-              className={
-                popup.kind === "success"
-                  ? "leading-tight text-foreground-secondary"
-                  : "leading-tight text-white/80"
-              }
-            >
-              {popup.message}
-            </p>
-          </div>
-        </Card>
-        <CardArrow
-          className="absolute left-1/2 top-full z-20 -translate-x-1/2 -translate-y-[10px]"
-          fillColor={
-            popup.kind === "success"
-              ? "var(--color-card-default)"
-              : "var(--color-primary-accent)"
-          }
-        />
-      </div>
+      <FloatingCardWithArrow
+        variant={popup.kind === "success" ? "default" : "primary"}
+        cardClassName="w-auto min-w-[220px] max-w-sm"
+      >
+        <div className="flex flex-col gap-1">
+          <p
+            className={cn(
+              "font-bold leading-tight",
+              popup.kind === "success" ? "text-foreground" : "text-white",
+            )}
+          >
+            {popup.kind === "success" ? "Search Ready" : "Search Needed"}
+          </p>
+          <p
+            className={cn(
+              "leading-tight",
+              popup.kind === "success"
+                ? "text-foreground-secondary"
+                : "text-white/80",
+            )}
+          >
+            {popup.message}
+          </p>
+        </div>
+      </FloatingCardWithArrow>
     </output>
   );
 }
@@ -134,7 +122,7 @@ export default function SearchBarShowcaseClient() {
               popup={popup?.searchKind === "default" ? popup : null}
             />
             <SearchBar
-              id={defaultSearchId}
+              inputId={defaultSearchId}
               placeholder="Default search bar..."
               onSearch={(value) =>
                 handleSearch("default", "Default search", value)
@@ -155,7 +143,7 @@ export default function SearchBarShowcaseClient() {
               popup={popup?.searchKind === "compact" ? popup : null}
             />
             <SearchBar
-              id={compactSearchId}
+              inputId={compactSearchId}
               variant="compact"
               placeholder="Compact search bar..."
               onSearch={(value) =>

--- a/src/app/ui_style/search-bar/page.tsx
+++ b/src/app/ui_style/search-bar/page.tsx
@@ -1,0 +1,15 @@
+import type { UIStylePageMeta } from "../common";
+import SearchBarShowcaseClient from "./SearchBarShowcaseClient";
+
+export const metadata: UIStylePageMeta = {
+  title: "Search Bar",
+  navLabel: "Search Bar",
+};
+
+export default function SearchBarShowcasePage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6">
+      <SearchBarShowcaseClient />
+    </main>
+  );
+}

--- a/src/ui/components/FloatingCardWithArrow.tsx
+++ b/src/ui/components/FloatingCardWithArrow.tsx
@@ -1,0 +1,55 @@
+import type * as React from "react";
+import { Card, type CardProps } from "@/ui/components/Card";
+import { CardArrow } from "@/ui/components/CardArrow";
+import { cn } from "@/utils/tailwind";
+
+const cardVariantFillColors: Record<
+  NonNullable<CardProps["variant"]>,
+  string
+> = {
+  default: "var(--color-card-default)",
+  secondary: "var(--color-card-secondary)",
+  primary: "var(--color-primary-accent)",
+};
+
+export interface FloatingCardWithArrowProps {
+  children: React.ReactNode;
+  variant?: NonNullable<CardProps["variant"]>;
+  noInnerShadow?: CardProps["noInnerShadow"];
+  shadowIntensity?: CardProps["shadowIntensity"];
+  className?: string;
+  cardClassName?: string;
+  arrowClassName?: string;
+  arrowFillColor?: string;
+}
+
+export function FloatingCardWithArrow({
+  children,
+  className,
+  cardClassName,
+  arrowClassName,
+  arrowFillColor,
+  variant = "default",
+  noInnerShadow = true,
+  shadowIntensity = "weakened",
+}: FloatingCardWithArrowProps) {
+  return (
+    <div className={cn("relative group tooltip-card-content", className)}>
+      <Card
+        variant={variant}
+        noInnerShadow={noInnerShadow}
+        shadowIntensity={shadowIntensity}
+        className={cn("p-4 peer border-3 card-content", cardClassName)}
+      >
+        {children}
+      </Card>
+      <CardArrow
+        className={cn(
+          "absolute left-1/2 top-full z-20 -translate-x-1/2 -translate-y-[10px]",
+          arrowClassName,
+        )}
+        fillColor={arrowFillColor ?? cardVariantFillColors[variant]}
+      />
+    </div>
+  );
+}

--- a/src/ui/components/SearchBar.tsx
+++ b/src/ui/components/SearchBar.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/utils/tailwind";
+
+const searchBarVariants = cva(
+  "flex items-center h-14 rounded-[28px] box-border overflow-hidden relative",
+  {
+    variants: {
+      variant: {
+        default: "w-[650px] max-w-full",
+        compact: "w-[320px] max-w-full",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+interface SearchBarProps
+  extends React.ComponentPropsWithoutRef<"form">,
+    VariantProps<typeof searchBarVariants> {
+  placeholder?: string;
+  onSearch?: (value: string) => void;
+}
+
+export const SearchBar = React.forwardRef<HTMLFormElement, SearchBarProps>(
+  (
+    {
+      className,
+      variant,
+      placeholder = "Search...",
+      onSearch,
+      onSubmit,
+      ...props
+    },
+    ref,
+  ) => {
+    const [query, setQuery] = React.useState("");
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+      onSubmit?.(e);
+      if (e.defaultPrevented) return;
+
+      const hasNativeSubmitTarget =
+        props.action !== undefined || props.method !== undefined;
+
+      if (onSearch) {
+        e.preventDefault();
+        onSearch(query);
+        return;
+      }
+
+      if (!hasNativeSubmitTarget) {
+        e.preventDefault();
+      }
+    };
+
+    return (
+      <form
+        ref={ref}
+        onSubmit={handleSubmit}
+        className={cn(
+          searchBarVariants({ variant }),
+          "bg-linear-to-b from-card-default to-mute",
+          "shadow-[0_12px_24px_color-mix(in_oklch,var(--color-shadow)_35%,transparent)]",
+          "pl-4",
+          className,
+        )}
+        {...props}
+      >
+        {/* Left Search Icon */}
+        <div className="flex items-center justify-center opacity-80 shrink-0">
+          <svg
+            width="25"
+            height="25"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-foreground-accent)"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </div>
+
+        {/* Text Input */}
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={placeholder}
+          className="flex-1 border-none bg-transparent outline-none text-lg px-4 min-w-0 placeholder:text-foreground/40"
+        />
+
+        {/* Right Gold Button */}
+        <button
+          type="submit"
+          aria-label="Submit search"
+          className={cn(
+            "h-full w-14 border-none cursor-pointer shrink-0",
+            "bg-linear-to-br from-[color-mix(in_oklch,var(--color-highlight)_90%,white)] to-icon-primary",
+            // "bg-linear-to-b from-[#FBD556] to-[#D89C19]",
+            "shadow-[inset_1px_1px_1px_color-mix(in_oklch,white_50%,transparent),inset_-1px_-1px_1px_color-mix(in_oklch,var(--color-shadow)_20%,transparent)]",
+            "flex items-center justify-center",
+            "rounded-tr-[28px] rounded-br-[28px]",
+            "transition-all duration-150",
+            "hover:brightness-105 active:brightness-95",
+          )}
+        >
+          <svg
+            width="25"
+            height="25"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-foreground-accent)"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </button>
+      </form>
+    );
+  },
+);
+SearchBar.displayName = "SearchBar";

--- a/src/ui/components/SearchBar.tsx
+++ b/src/ui/components/SearchBar.tsx
@@ -21,114 +21,109 @@ const searchBarVariants = cva(
 );
 
 interface SearchBarProps
-  extends React.ComponentPropsWithoutRef<"form">,
+  extends React.ComponentPropsWithRef<"div">,
     VariantProps<typeof searchBarVariants> {
+  inputId?: string;
   placeholder?: string;
   onSearch?: (value: string) => void;
 }
 
-export const SearchBar = React.forwardRef<HTMLFormElement, SearchBarProps>(
-  (
-    {
-      className,
-      variant,
-      placeholder = "Search...",
-      onSearch,
-      onSubmit,
-      ...props
-    },
-    ref,
-  ) => {
-    const [query, setQuery] = React.useState("");
+export function SearchBar({
+  className,
+  variant,
+  inputId,
+  placeholder = "Search...",
+  onSearch,
+  ref,
+  ...props
+}: SearchBarProps) {
+  const [query, setQuery] = React.useState("");
 
-    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-      onSubmit?.(e);
-      if (e.defaultPrevented) return;
+  const handleSearch = () => {
+    onSearch?.(query);
+  };
 
-      const hasNativeSubmitTarget =
-        props.action !== undefined || props.method !== undefined;
-
-      if (onSearch) {
-        e.preventDefault();
-        onSearch(query);
-        return;
-      }
-
-      if (!hasNativeSubmitTarget) {
-        e.preventDefault();
-      }
-    };
-
-    return (
-      <form
-        ref={ref}
-        onSubmit={handleSubmit}
-        className={cn(
-          searchBarVariants({ variant }),
-          "bg-linear-to-b from-card-default to-mute",
-          "shadow-[0_12px_24px_color-mix(in_oklch,var(--color-shadow)_35%,transparent)]",
-          "pl-4",
-          className,
-        )}
-        {...props}
-      >
-        {/* Left Search Icon */}
-        <div className="flex items-center justify-center opacity-80 shrink-0">
-          <svg
-            width="25"
-            height="25"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="var(--color-foreground-accent)"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="11" cy="11" r="8" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
-          </svg>
-        </div>
-
-        {/* Text Input */}
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder={placeholder}
-          className="flex-1 border-none bg-transparent outline-none text-lg px-4 min-w-0 placeholder:text-foreground/40"
-        />
-
-        {/* Right Gold Button */}
-        <button
-          type="submit"
-          aria-label="Submit search"
-          className={cn(
-            "h-full w-14 border-none cursor-pointer shrink-0",
-            "bg-linear-to-br from-[color-mix(in_oklch,var(--color-highlight)_90%,white)] to-icon-primary",
-            // "bg-linear-to-b from-[#FBD556] to-[#D89C19]",
-            "shadow-[inset_1px_1px_1px_color-mix(in_oklch,white_50%,transparent),inset_-1px_-1px_1px_color-mix(in_oklch,var(--color-shadow)_20%,transparent)]",
-            "flex items-center justify-center",
-            "rounded-tr-[28px] rounded-br-[28px]",
-            "transition-all duration-150",
-            "hover:brightness-105 active:brightness-95",
-          )}
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        searchBarVariants({ variant }),
+        "bg-linear-to-b from-card-default to-mute",
+        "shadow-[0_12px_24px_color-mix(in_oklch,var(--color-shadow)_35%,transparent)]",
+        "pl-4",
+        className,
+      )}
+      {...props}
+    >
+      {/* Left Search Icon */}
+      <div className="flex items-center justify-center opacity-80 shrink-0">
+        <svg
+          width="25"
+          height="25"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="var(--color-foreground-accent)"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         >
-          <svg
-            width="25"
-            height="25"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="var(--color-foreground-accent)"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="11" cy="11" r="8" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
-          </svg>
-        </button>
-      </form>
-    );
-  },
-);
-SearchBar.displayName = "SearchBar";
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </div>
+
+      {/* Text Input */}
+      <input
+        id={inputId}
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (
+            e.defaultPrevented ||
+            e.key !== "Enter" ||
+            e.nativeEvent.isComposing
+          ) {
+            return;
+          }
+
+          e.preventDefault();
+          handleSearch();
+        }}
+        placeholder={placeholder}
+        className="flex-1 border-none bg-transparent outline-none text-lg px-4 min-w-0 placeholder:text-foreground/40"
+      />
+
+      {/* Right Gold Button */}
+      <button
+        type="button"
+        aria-label="Submit search"
+        onClick={handleSearch}
+        className={cn(
+          "h-full w-14 border-none cursor-pointer shrink-0",
+          "bg-linear-to-br from-[color-mix(in_oklch,var(--color-highlight)_90%,white)] to-icon-primary",
+          // "bg-linear-to-b from-[#FBD556] to-[#D89C19]",
+          "shadow-[inset_1px_1px_1px_color-mix(in_oklch,white_50%,transparent),inset_-1px_-1px_1px_color-mix(in_oklch,var(--color-shadow)_20%,transparent)]",
+          "flex items-center justify-center",
+          "rounded-tr-[28px] rounded-br-[28px]",
+          "transition-all duration-150",
+          "hover:brightness-105 active:brightness-95",
+        )}
+      >
+        <svg
+          width="25"
+          height="25"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="var(--color-foreground-accent)"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
### TL;DR

Adds a new `SearchBar` reusable component and a corresponding UI style showcase page.

### What changed?

- Introduced a new `SearchBar` component (`src/ui/components/SearchBar.tsx`) built as a `<form>` element with `default` and `compact` size variants. It includes a text input, a left-side search icon, and a styled submit button. Submission behavior respects native form actions, an `onSearch` callback, or prevents default if neither is provided.
- Added a showcase page at `/ui_style/search-bar` that renders both the `default` and `compact` variants side by side. Each variant displays a tooltip popup on submission — a success state when a query is entered, or an error state when the input is empty.
- Registered the new page in the nav items list under "Search Bar".

### How to test?

1. Navigate to `/ui_style/search-bar`.
2. Type a query into the **Default** search bar and click the submit button — a "Search Ready" tooltip should appear briefly above the input.
3. Click submit on the **Default** search bar without typing anything — a "Search Needed" error tooltip should appear.
4. Repeat steps 2 and 3 for the **Compact** search bar.
5. Confirm the "Search Bar" link appears in the UI style navigation and routes correctly.

### Why make this change?

The `SearchBar` component was missing from the shared UI component library and style showcase. Adding it ensures the component is documented, visually testable, and available for use across the application.

### Showcase


https://github.com/user-attachments/assets/b1b947be-dd52-456d-8aa2-e43d701d1de0

