### PR TITLE
chore: refactor ItemsPreview and update Next.js version to 15.5.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "lodash": "^4.17.23",
         "lucide-react": "^0.522.0",
         "motion": "^12.23.9",
-        "next": "^15.5.15",
+        "next": "^15.5.18",
         "next-auth": "^5.0.0-beta.30",
         "next-themes": "^0.4.6",
         "number-to-words": "^1.2.4",
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
-      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
+      "integrity": "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2098,9 +2098,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
-      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.18.tgz",
+      "integrity": "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2114,9 +2114,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
-      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.18.tgz",
+      "integrity": "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==",
       "cpu": [
         "x64"
       ],
@@ -2130,9 +2130,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
-      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.18.tgz",
+      "integrity": "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==",
       "cpu": [
         "arm64"
       ],
@@ -2146,9 +2146,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
-      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.18.tgz",
+      "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
       ],
@@ -2162,9 +2162,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
-      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.18.tgz",
+      "integrity": "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==",
       "cpu": [
         "x64"
       ],
@@ -2178,9 +2178,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
-      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.18.tgz",
+      "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
       ],
@@ -2194,9 +2194,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
-      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.18.tgz",
+      "integrity": "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==",
       "cpu": [
         "arm64"
       ],
@@ -2210,9 +2210,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
-      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.18.tgz",
+      "integrity": "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==",
       "cpu": [
         "x64"
       ],
@@ -8631,12 +8631,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
-      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
+      "version": "15.5.18",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
+      "integrity": "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.15",
+        "@next/env": "15.5.18",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -8649,14 +8649,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.15",
-        "@next/swc-darwin-x64": "15.5.15",
-        "@next/swc-linux-arm64-gnu": "15.5.15",
-        "@next/swc-linux-arm64-musl": "15.5.15",
-        "@next/swc-linux-x64-gnu": "15.5.15",
-        "@next/swc-linux-x64-musl": "15.5.15",
-        "@next/swc-win32-arm64-msvc": "15.5.15",
-        "@next/swc-win32-x64-msvc": "15.5.15",
+        "@next/swc-darwin-arm64": "15.5.18",
+        "@next/swc-darwin-x64": "15.5.18",
+        "@next/swc-linux-arm64-gnu": "15.5.18",
+        "@next/swc-linux-arm64-musl": "15.5.18",
+        "@next/swc-linux-x64-gnu": "15.5.18",
+        "@next/swc-linux-x64-musl": "15.5.18",
+        "@next/swc-win32-arm64-msvc": "15.5.18",
+        "@next/swc-win32-x64-msvc": "15.5.18",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "^4.17.23",
     "lucide-react": "^0.522.0",
     "motion": "^12.23.9",
-    "next": "^15.5.15",
+    "next": "^15.5.18",
     "next-auth": "^5.0.0-beta.30",
     "next-themes": "^0.4.6",
     "number-to-words": "^1.2.4",

--- a/src/app/house_layout/[room]/LocationsList.tsx
+++ b/src/app/house_layout/[room]/LocationsList.tsx
@@ -20,11 +20,11 @@ function ItemsPreview({ items }: { items?: LocationItem[] }) {
           return (
             <div
               key={item.id}
-              className="grid grid-cols-[auto_1fr_auto] items-center gap-x-2 gap-y-1 text-base leading-snug text-gray-800"
+              className="flex items-start gap-2 text-base leading-snug text-gray-800"
             >
-              <span className="min-w-0 break-words">{item.name}</span>
+              <span className="min-w-0 flex-1 break-words">{item.name}</span>
               {item.quantity && (
-                <span className="justify-self-end bg-gray-200/60 px-1 rounded text-base whitespace-nowrap flex-shrink-0">
+                <span className="ml-auto inline-flex min-w-6 flex-shrink-0 items-center justify-center whitespace-nowrap rounded bg-gray-200/60 px-1.5 text-base tabular-nums leading-none text-right">
                   {item.quantity}
                 </span>
               )}
@@ -102,25 +102,10 @@ export default function LocationsList({
               position="bottom"
               variant="bubble"
               content={
-                <div className="flex w-full min-w-[260px] max-w-[640px] whitespace-normal break-words">
-                  {/* Left side - Location info */}
-                  <div className="w-1/2 pr-2 min-w-0">
-                    <h4 className="font-bold text-lg mb-1 break-words leading-snug text-gray-900">
-                      {location.name}
-                    </h4>
-                    <p className="text-base text-gray-700 break-words leading-snug">
-                      Total: {location.items?.length || 0} items
-                    </p>
-                  </div>
-                  {/* Right side - Items list */}
-                  <div className="w-1/2 pl-2 border-l border-gray-300/60 min-w-0">
-                    <p className="font-medium text-base mb-1 text-gray-900">
-                      Items:
-                    </p>
-                    <ItemsPreview
-                      items={location.items as LocationItem[] | undefined}
-                    />
-                  </div>
+                <div className="min-w-[220px] max-w-[360px] whitespace-normal break-words">
+                  <ItemsPreview
+                    items={location.items as LocationItem[] | undefined}
+                  />
                 </div>
               }
               className="block"


### PR DESCRIPTION
### TL;DR

Simplify the location tooltip (Items Preview) layout in the house layout view and Upgrades Next.js from `15.5.15` to `15.5.18`

### What changed?

- Next.js bumped to `15.5.18`.
- The location tooltip (Items Preview) in `LocationsList.tsx` has been simplified from a two-column layout (location info on the left, items list on the right) to a single-column layout showing only the items preview. 

### How to test?

1. Run `npm install` to pull in the updated Next.js version.
2. Navigate to a room in the house layout view and hover over a location marker to verify the tooltip renders correctly with the simplified single-column items list.
3. Check that item names wrap properly and quantity badges are aligned and display correctly for varying quantity values.

### Why make this change?

The two-column tooltip layout was overly complex and included redundant information (location name and item count) that added visual noise. Simplifying it to just the items list makes the tooltip cleaner and more focused. The flex-based item row layout also improves alignment and rendering consistency for the quantity badge.

### Version Comparation
<img width="890" height="341" alt="vs" src="https://github.com/user-attachments/assets/be7bfff7-d9e8-4208-bc5d-6456f479ecfc" />

