### PR TITLE
Replace phaser3-rex-plugins with custom Phaser utility classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "number-to-words": "^1.2.4",
         "openai": "^6.16.0",
         "phaser": "^3.80.1",
-        "phaser3-rex-plugins": "^1.80.17",
         "pluralize": "^8.0.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -4519,6 +4518,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -5373,14 +5373,6 @@
         "toggle-selection": "^1.0.6"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5427,16 +5419,6 @@
       "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -6461,6 +6443,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -6963,35 +6946,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/graphology": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.25.4.tgz",
-      "integrity": "sha512-33g0Ol9nkWdD6ulw687viS8YJQBxqG5LWII6FI6nul0pq6iM2t5EKquOTFDbyTblRB3O9I+7KX4xI8u5ffekAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0",
-        "obliterator": "^2.0.2"
-      },
-      "peerDependencies": {
-        "graphology-types": ">=0.24.0"
-      }
-    },
-    "node_modules/graphology-types": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
-      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -7136,36 +7090,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
-    },
-    "node_modules/i18next": {
-      "version": "22.5.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.5.1.tgz",
-      "integrity": "sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "dependencies": {
-        "@babel/runtime": "^7.20.6"
-      }
-    },
-    "node_modules/i18next-http-backend": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.5.2.tgz",
-      "integrity": "sha512-+K8HbDfrvc1/2X8jpb7RLhI9ZxBDpx3xogYkQwGKlWAUXLSEGXzgdt3EcUjLlBCdMwdQY+K+EUF6oh8oB6rwHw==",
-      "dependencies": {
-        "cross-fetch": "4.0.0"
-      }
     },
     "node_modules/iconify-icon": {
       "version": "2.1.0",
@@ -7856,6 +7780,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8546,15 +8471,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
-    },
     "node_modules/mute-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
@@ -8776,26 +8692,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
@@ -8988,12 +8884,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obliterator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
-      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
-      "license": "MIT"
-    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -9181,11 +9071,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/papaparse": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
-      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9275,28 +9160,6 @@
       "dependencies": {
         "eventemitter3": "^5.0.1"
       }
-    },
-    "node_modules/phaser3-rex-plugins": {
-      "version": "1.80.17",
-      "resolved": "https://registry.npmjs.org/phaser3-rex-plugins/-/phaser3-rex-plugins-1.80.17.tgz",
-      "integrity": "sha512-0xNgjA2rbh9323hP1dFwasYgKO1CyYJO6PwznnNTaWnn8ksbg9VQhprpAp4ASxSPkfn1ISgzxw8LqWjNJK8Rew==",
-      "license": "MIT",
-      "dependencies": {
-        "dagre": "^0.8.5",
-        "eventemitter3": "^3.1.2",
-        "graphology": "^0.25.4",
-        "i18next": "^22.5.1",
-        "i18next-http-backend": "^2.5.2",
-        "js-yaml": "^4.1.0",
-        "mustache": "^4.2.0",
-        "papaparse": "^5.4.1",
-        "webfontloader": "^1.6.28"
-      }
-    },
-    "node_modules/phaser3-rex-plugins/node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -10883,12 +10746,6 @@
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -11277,17 +11134,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webfontloader": {
-      "version": "1.6.28",
-      "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
-      "integrity": "sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ=="
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack": {
       "version": "5.105.4",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
@@ -11427,16 +11273,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "number-to-words": "^1.2.4",
     "openai": "^6.16.0",
     "phaser": "^3.80.1",
-    "phaser3-rex-plugins": "^1.80.17",
     "pluralize": "^8.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/phaser/Game.tsx
+++ b/phaser/Game.tsx
@@ -60,7 +60,6 @@ export default function PhaserGame({
 
     return () => {
       if (game.current) {
-        game.current.plugins.removeGlobalPlugin("rexInputTextPlugin");
         game.current.destroy(true);
         game.current = undefined;
       }

--- a/phaser/gameConfig.ts
+++ b/phaser/gameConfig.ts
@@ -1,7 +1,4 @@
 import { getSharedLoadingScene } from "@phaser/loadingScene";
-import AnchorPlugin from "phaser3-rex-plugins/plugins/anchor-plugin";
-import InputTextPlugin from "phaser3-rex-plugins/plugins/inputtext-plugin";
-import UIPlugin from "phaser3-rex-plugins/templates/ui/ui-plugin";
 
 export function createConfig(secondScene?: Phaser.Types.Scenes.SceneType) {
   const scene: Phaser.Types.Scenes.SceneType[] = [getSharedLoadingScene()];
@@ -28,29 +25,6 @@ export function createConfig(secondScene?: Phaser.Types.Scenes.SceneType) {
         gravity: { x: 0, y: 300 },
         debug: false,
       },
-    },
-    // ...
-    plugins: {
-      scene: [
-        {
-          key: "rexUI",
-          plugin: UIPlugin,
-          mapping: "rexUI",
-        },
-      ],
-
-      global: [
-        {
-          key: "rexInputTextPlugin",
-          plugin: InputTextPlugin,
-          start: true,
-        },
-        {
-          key: "rexAnchor",
-          plugin: AnchorPlugin,
-          start: true,
-        },
-      ],
     },
   };
 }

--- a/phaser/scenes/LoaderScene.ts
+++ b/phaser/scenes/LoaderScene.ts
@@ -1,7 +1,7 @@
 import { markSharedLoaderSeen } from "@phaser/sharedLoaderSession";
+import { applyAnchor } from "@phaser/utils";
 import { sortBy } from "lodash";
 import * as Phaser from "phaser";
-import type AnchorPlugin from "phaser3-rex-plugins/plugins/anchor-plugin";
 
 export class LoaderScene extends Phaser.Scene {
   private sprite!: Phaser.GameObjects.Sprite;
@@ -29,9 +29,10 @@ export class LoaderScene extends Phaser.Scene {
 
     this.sprite = this.add.sprite(0, 0, "loader", frameNames[0]);
 
-    (this.plugins.get("rexAnchor") as AnchorPlugin)!.add(this.sprite, {
-      centerX: "center",
-      centerY: "center-100",
+    applyAnchor(this.sprite, this, {
+      centerX: true,
+      centerY: true,
+      offsetY: -100,
     });
 
     this.sprite.once(Phaser.Animations.Events.ANIMATION_COMPLETE, () => {

--- a/phaser/utils/DoubleTap.ts
+++ b/phaser/utils/DoubleTap.ts
@@ -1,0 +1,92 @@
+import type * as Phaser from "phaser";
+
+export interface DoubleTapConfig {
+  taps?: number;
+  interval?: number;
+  moveThreshold?: number;
+}
+
+type DoubleTapCallback = () => void;
+
+export class DoubleTap {
+  private scene: Phaser.Scene;
+  private config: Required<DoubleTapConfig>;
+  private tapTimes: number[] = [];
+  private startX = 0;
+  private startY = 0;
+  private isTracking = false;
+  private callbacks: Map<string, DoubleTapCallback> = new Map();
+  private target: Phaser.GameObjects.GameObject;
+  private destroyed = false;
+
+  constructor(
+    scene: Phaser.Scene,
+    target: Phaser.GameObjects.GameObject,
+    config: DoubleTapConfig = {},
+  ) {
+    this.scene = scene;
+    this.target = target;
+    this.config = {
+      taps: config.taps ?? 2,
+      interval: config.interval ?? 300,
+      moveThreshold: config.moveThreshold ?? 10,
+    };
+
+    target.on("pointerdown", this.onPointerDown, this);
+    scene.events.once("shutdown", this.destroy, this);
+  }
+
+  private onPointerDown = (pointer: Phaser.Input.Pointer): void => {
+    if (this.destroyed) return;
+
+    const now = Date.now();
+
+    if (!this.isTracking) {
+      this.tapTimes = [now];
+      this.startX = pointer.x;
+      this.startY = pointer.y;
+      this.isTracking = true;
+      return;
+    }
+
+    const dx = Math.abs(pointer.x - this.startX);
+    const dy = Math.abs(pointer.y - this.startY);
+
+    if (dx > this.config.moveThreshold || dy > this.config.moveThreshold) {
+      this.isTracking = false;
+      this.tapTimes = [];
+      return;
+    }
+
+    const lastTap = this.tapTimes[this.tapTimes.length - 1];
+    if (now - lastTap <= this.config.interval) {
+      this.tapTimes.push(now);
+      if (this.tapTimes.length >= this.config.taps) {
+        this.emit("tap");
+        this.tapTimes = [];
+        this.isTracking = false;
+      }
+    } else {
+      this.tapTimes = [now];
+      this.startX = pointer.x;
+      this.startY = pointer.y;
+    }
+  };
+
+  on(event: "tap", callback: DoubleTapCallback): this {
+    this.callbacks.set(event, callback);
+    return this;
+  }
+
+  private emit(event: string): void {
+    const cb = this.callbacks.get(event);
+    if (cb) cb();
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.target.off("pointerdown", this.onPointerDown, this);
+    this.scene.events.off("shutdown", this.destroy, this);
+  }
+}

--- a/phaser/utils/HTMLInputText.ts
+++ b/phaser/utils/HTMLInputText.ts
@@ -1,0 +1,129 @@
+import * as Phaser from "phaser";
+
+export interface HTMLInputTextConfig {
+  width?: number;
+  height?: number;
+  text?: string;
+  fontSize?: string;
+  color?: string;
+  align?: "left" | "center" | "right";
+  placeholder?: string;
+}
+
+export class HTMLInputText extends Phaser.GameObjects.Rectangle {
+  private inputElement!: HTMLInputElement;
+  private wrapper!: HTMLDivElement;
+  private callbacks = new Map<string, (input: HTMLInputText) => void>();
+
+  private _lastX = -9999;
+  private _lastY = -9999;
+
+  constructor(scene: Phaser.Scene, config: HTMLInputTextConfig = {}) {
+    super(scene, 0, 0, config.width ?? 200, config.height ?? 40, 0x000000, 0);
+
+    this.initDOM();
+    this.applyConfig(config);
+
+    scene.events.on("update", this.update, this);
+    scene.game.events.once("destroy", this.destroy, this);
+  }
+
+  private applyConfig(config: HTMLInputTextConfig): void {
+    if (config.width !== undefined) {
+      this.inputElement.style.width = `${config.width}px`;
+    }
+    if (config.height !== undefined) {
+      this.inputElement.style.height = `${config.height}px`;
+    }
+    if (config.fontSize) {
+      this.inputElement.style.fontSize = config.fontSize;
+    }
+    if (config.color) {
+      this.inputElement.style.color = config.color;
+    }
+    if (config.align) {
+      this.inputElement.style.textAlign = config.align;
+    }
+    if (config.placeholder) {
+      this.inputElement.placeholder = config.placeholder;
+    }
+    if (config.text) {
+      this.inputElement.value = config.text;
+    }
+
+    this.inputElement.style.transform = "translate(-50%, 0)";
+  }
+
+  private initDOM(): void {
+    const canvas = this.scene.sys.game.canvas;
+    const rect = canvas.getBoundingClientRect();
+
+    this.wrapper = document.createElement("div");
+    this.wrapper.style.position = "absolute";
+    this.wrapper.style.pointerEvents = "none";
+    this.wrapper.style.overflow = "hidden";
+    this.wrapper.style.left = `${rect.left}px`;
+    this.wrapper.style.top = `${rect.top}px`;
+    this.wrapper.style.width = `${rect.width}px`;
+    this.wrapper.style.height = `${rect.height}px`;
+    document.body.appendChild(this.wrapper);
+
+    this.inputElement = document.createElement("input");
+    this.inputElement.type = "text";
+    this.inputElement.style.position = "absolute";
+    this.inputElement.style.pointerEvents = "auto";
+    this.inputElement.style.border = "none";
+    this.inputElement.style.background = "transparent";
+    this.inputElement.style.outline = "none";
+    this.inputElement.style.padding = "0";
+    this.inputElement.style.margin = "0";
+    this.inputElement.style.fontFamily = "sans-serif";
+    this.inputElement.style.left = "0px";
+    this.inputElement.style.top = "0px";
+
+    this.wrapper.appendChild(this.inputElement);
+  }
+
+  update(): void {
+    const px = this.x;
+    const py = this.y;
+
+    if (px !== this._lastX || py !== this._lastY) {
+      this._lastX = px;
+      this._lastY = py;
+
+      const point = new Phaser.Math.Vector2();
+      const canvas = this.scene.sys.game.canvas;
+      const rect = canvas.getBoundingClientRect();
+      const scale = this.scene.scale;
+
+      this.getWorldTransformMatrix().transformPoint(px, py, point);
+
+      this.inputElement.style.left = `${rect.left + point.x / scale.displayScale.x}px`;
+      this.inputElement.style.top = `${rect.top + point.y / scale.displayScale.y}px`;
+    }
+  }
+
+  get text(): string {
+    return this.inputElement.value;
+  }
+
+  set text(value: string) {
+    this.inputElement.value = value;
+  }
+
+  onTextChange(callback: (input: HTMLInputText) => void): this {
+    this.inputElement.addEventListener("input", () => {
+      callback(this);
+    });
+    this.callbacks.set("textchange", callback);
+    return this;
+  }
+
+  override destroy(fromScene?: boolean): void {
+    this.scene.events.off("update", this.update, this);
+    this.scene.game.events.off("destroy", this.destroy, this);
+    this.wrapper?.remove();
+    super.destroy(fromScene);
+  }
+}

--- a/phaser/utils/OverlapSizer.ts
+++ b/phaser/utils/OverlapSizer.ts
@@ -1,0 +1,168 @@
+import * as Phaser from "phaser";
+import type { AnchorConfig } from "./applyAnchor";
+import { applyAnchor } from "./applyAnchor";
+import type { ChildConfig } from "./common";
+import { clearBounds, drawBounds } from "./common";
+
+export class OverlapSizer extends Phaser.GameObjects.Container {
+  private readonly anchorConfig: AnchorConfig;
+  private readonly childConfigs = new Map<
+    Phaser.GameObjects.GameObject,
+    ChildConfig
+  >();
+  private lastRefWidth = 0;
+  private lastRefHeight = 0;
+
+  constructor(scene: Phaser.Scene, anchorConfig: AnchorConfig = {}) {
+    super(scene);
+    this.anchorConfig = anchorConfig;
+
+    // Auto-add to scene if not already added to a container
+    if (this.parentContainer === null) {
+      scene.add.existing(this);
+    }
+
+    this.reapplyAnchor();
+    scene.scale.on("resize", this.handleResize, this);
+    scene.events.once("shutdown", this.removeResizeListener, this);
+  }
+
+  addChild(
+    gameObject: Phaser.GameObjects.GameObject,
+    childConfig: ChildConfig = {},
+  ): this {
+    this.childConfigs.set(gameObject, childConfig);
+    this.add(gameObject);
+    this.layoutChild(gameObject, childConfig);
+
+    return this;
+  }
+
+  layout(): void {
+    for (const child of this.list) {
+      const gameObject = child as Phaser.GameObjects.GameObject;
+      this.layoutChild(gameObject, this.childConfigs.get(gameObject) ?? {});
+    }
+  }
+
+  preUpdate(): void {
+    const { width, height } = this.getAnchorReferenceSize();
+    if (width !== this.lastRefWidth || height !== this.lastRefHeight) {
+      this.reapplyAnchor();
+      this.layout();
+    }
+  }
+
+  destroy(fromScene?: boolean): void {
+    this.removeResizeListener();
+    this.scene?.events.off("shutdown", this.removeResizeListener, this);
+    clearBounds(this);
+    super.destroy(fromScene);
+  }
+
+  private handleResize(): void {
+    this.reapplyAnchor();
+    this.layout();
+  }
+
+  private removeResizeListener(): void {
+    this.scene?.scale.off("resize", this.handleResize, this);
+  }
+
+  private reapplyAnchor(): void {
+    applyAnchor(this, this.scene, this.anchorConfig);
+
+    const { width, height } = this.getAnchorReferenceSize();
+    this.lastRefWidth = width;
+    this.lastRefHeight = height;
+  }
+
+  private getAnchorReferenceSize(): { width: number; height: number } {
+    const parent = this.parentContainer as any;
+    const parentBounds = parent?.getBounds?.();
+
+    return {
+      width:
+        parent?.width ||
+        parent?.displayWidth ||
+        parentBounds?.width ||
+        this.scene.scale.width,
+      height:
+        parent?.height ||
+        parent?.displayHeight ||
+        parentBounds?.height ||
+        this.scene.scale.height,
+    };
+  }
+
+  private layoutChild(
+    gameObject: Phaser.GameObjects.GameObject,
+    childConfig: ChildConfig,
+  ): void {
+    const align = childConfig.align ?? "center-center";
+    const minW = childConfig.minWidth ?? 0;
+    const minH = childConfig.minHeight ?? 0;
+    const pad = childConfig.padding ?? {};
+    const expand = childConfig.expand ?? {};
+
+    let targetX: number;
+    let targetY: number;
+
+    if (align === "center-center") {
+      targetX = (pad.left ?? 0) - (pad.right ?? 0);
+      targetY = (pad.top ?? 0) - (pad.bottom ?? 0);
+    } else {
+      // More alignment options can be added here; center is the current behavior.
+      targetX = (pad.left ?? 0) - (pad.right ?? 0);
+      targetY = (pad.top ?? 0) - (pad.bottom ?? 0);
+    }
+
+    (gameObject as any).x = targetX;
+    (gameObject as any).y = targetY;
+
+    const availW = expand.width
+      ? this.width - (pad.left ?? 0) - (pad.right ?? 0)
+      : undefined;
+    const availH = expand.height
+      ? this.height - (pad.top ?? 0) - (pad.bottom ?? 0)
+      : undefined;
+
+    if (availW !== undefined || availH !== undefined) {
+      const finalW =
+        availW ??
+        (gameObject as any).width ??
+        (gameObject as any).displayWidth ??
+        minW;
+      const finalH =
+        availH ??
+        (gameObject as any).height ??
+        (gameObject as any).displayHeight ??
+        minH;
+      if ("setSize" in gameObject) {
+        (gameObject as any).setSize(finalW, finalH);
+      } else if ("setDisplaySize" in gameObject) {
+        (gameObject as any).setDisplaySize(finalW, finalH);
+      }
+    }
+  }
+
+  drawBounds(color: number = 0xff0000, alpha: number = 0.3): this {
+    const w = (this as any).width;
+    const h = (this as any).height;
+
+    const drawX =
+      (this as any).width > 0 ? this.x - (this as any).width / 2 : this.x;
+    const drawY =
+      (this as any).height > 0 ? this.y - (this as any).height / 2 : this.y;
+
+    console.debug("OverlapSizer bounds:", {
+      x: drawX,
+      y: drawY,
+      width: w,
+      height: h,
+    });
+
+    drawBounds(this, this.scene, color, alpha);
+    return this;
+  }
+}

--- a/phaser/utils/ScrollablePanel.ts
+++ b/phaser/utils/ScrollablePanel.ts
@@ -1,0 +1,338 @@
+import * as Phaser from "phaser";
+import { Orientation, Sizer } from "./Sizer";
+
+export interface ScrollablePanelConfig {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+  space?: {
+    item?: number;
+    left?: number;
+    right?: number;
+    top?: number;
+    bottom?: number;
+  };
+}
+
+export interface ScrollablePanelBackgroundConfig {
+  fillColor?: number;
+  fillAlpha?: number;
+  cornerRadius?: number;
+  strokeColor?: number;
+  strokeWidth?: number;
+}
+
+export class ScrollablePanel extends Phaser.GameObjects.Container {
+  private widthVal: number;
+  private heightVal: number;
+  private scrollY = 0;
+  private maxScrollY = 0;
+  private sizer: Sizer;
+  private scrollbar: Phaser.GameObjects.Graphics;
+  private scrollbarBg: Phaser.GameObjects.Graphics;
+  private viewportMaskGraphics: Phaser.GameObjects.Graphics;
+  private viewportMask: Phaser.Display.Masks.GeometryMask;
+  private background: Phaser.GameObjects.Graphics | null = null;
+  private backgroundConfig: ScrollablePanelBackgroundConfig | null = null;
+  private _prevWidth: number;
+  private _prevHeight: number;
+  private visibleArea: Phaser.Geom.Rectangle;
+
+  constructor(scene: Phaser.Scene, config: ScrollablePanelConfig) {
+    super(scene);
+    super.setVisible(false);
+
+    if (config.x !== undefined) this.x = config.x;
+    if (config.y !== undefined) this.y = config.y;
+
+    this.widthVal = config.width;
+    this.heightVal = config.height;
+    this._prevWidth = config.width;
+    this._prevHeight = config.height;
+    this.setSize(config.width, config.height);
+    this.visibleArea = new Phaser.Geom.Rectangle(
+      -config.width / 2,
+      -config.height / 2,
+      config.width,
+      0,
+    );
+
+    // Add container to scene FIRST so applyAnchor can position it correctly
+    scene.add.existing(this);
+
+    // Create sizer as the content layout manager
+    this.sizer = new Sizer(scene, {
+      orientation: Orientation.Vertical,
+      space: config.space,
+    });
+    this.sizer.setSize(config.width, config.height);
+    super.add(this.sizer);
+
+    this.viewportMaskGraphics = new Phaser.GameObjects.Graphics(scene);
+    this.viewportMask = this.sizer.createGeometryMask(
+      this.viewportMaskGraphics,
+    );
+    this.sizer.setMask(this.viewportMask);
+
+    // Scrollbar background
+    this.scrollbarBg = scene.add.graphics();
+    super.add(this.scrollbarBg);
+
+    // Scrollbar thumb
+    this.scrollbar = scene.add.graphics();
+    super.add(this.scrollbar);
+
+    // Setup wheel scrolling
+    scene.input.on("wheel", this.onWheel, this);
+    scene.events.once("shutdown", this.destroy, this);
+
+    this.drawScrollbar();
+  }
+
+  private hasContent(): boolean {
+    return this.sizer.list.length > 0;
+  }
+
+  private updateVisibility(): void {
+    super.setVisible(this.hasContent());
+  }
+
+  private updateVisibleArea(): void {
+    const contentSize = this.sizer.getContentSize();
+
+    this.visibleArea.setTo(
+      -this.widthVal / 2,
+      -this.heightVal / 2,
+      this.widthVal,
+      Math.min(this.heightVal, contentSize.height),
+    );
+  }
+
+  preUpdate(): void {
+    if (!this.sizer || !this.scene) return;
+    if (this.width !== this._prevWidth || this.height !== this._prevHeight) {
+      this._prevWidth = this.width;
+      this._prevHeight = this.height;
+      this.widthVal = this.width;
+      this.heightVal = this.height;
+      this.layout();
+    }
+  }
+
+  private drawBackground(): void {
+    if (!this.backgroundConfig) return;
+
+    if (!this.background) {
+      this.background = new Phaser.GameObjects.Graphics(this.scene);
+      super.addAt(this.background, 0);
+    }
+
+    this.background.clear();
+    this.background.setPosition(this.visibleArea.x, this.visibleArea.y);
+
+    const alpha = this.backgroundConfig.fillAlpha ?? 1;
+    const radius = this.backgroundConfig.cornerRadius ?? 0;
+
+    if (this.backgroundConfig.fillColor !== undefined) {
+      this.background.fillStyle(this.backgroundConfig.fillColor, alpha);
+      this.background.fillRoundedRect(
+        0,
+        0,
+        this.visibleArea.width,
+        this.visibleArea.height,
+        radius,
+      );
+    }
+    if (
+      this.backgroundConfig.strokeWidth &&
+      this.backgroundConfig.strokeColor !== undefined
+    ) {
+      this.background.lineStyle(
+        this.backgroundConfig.strokeWidth,
+        this.backgroundConfig.strokeColor,
+      );
+      this.background.strokeRoundedRect(
+        0,
+        0,
+        this.visibleArea.width,
+        this.visibleArea.height,
+        radius,
+      );
+    }
+  }
+
+  addBackground(config: ScrollablePanelBackgroundConfig): this {
+    this.backgroundConfig = config;
+    this.drawBackground();
+    return this;
+  }
+
+  add<T extends Phaser.GameObjects.GameObject>(child: T | T[]): this {
+    this.sizer.add(child);
+    this.layout();
+    return this;
+  }
+
+  private getVisibleAreaBounds(): Phaser.Geom.Rectangle {
+    const left = this.visibleArea.left;
+    const right = this.visibleArea.right;
+    const top = this.visibleArea.top;
+    const bottom = this.visibleArea.bottom;
+    const worldMatrix = this.getWorldTransformMatrix();
+    const topLeft = worldMatrix.transformPoint(left, top);
+    const topRight = worldMatrix.transformPoint(right, top);
+    const bottomRight = worldMatrix.transformPoint(right, bottom);
+    const bottomLeft = worldMatrix.transformPoint(left, bottom);
+    const minX = Math.min(topLeft.x, topRight.x, bottomRight.x, bottomLeft.x);
+    const maxX = Math.max(topLeft.x, topRight.x, bottomRight.x, bottomLeft.x);
+    const minY = Math.min(topLeft.y, topRight.y, bottomRight.y, bottomLeft.y);
+    const maxY = Math.max(topLeft.y, topRight.y, bottomRight.y, bottomLeft.y);
+
+    return new Phaser.Geom.Rectangle(minX, minY, maxX - minX, maxY - minY);
+  }
+
+  private getViewportCorners(): Phaser.Types.Math.Vector2Like[] {
+    const left = -this.widthVal / 2;
+    const right = this.widthVal / 2;
+    const top = -this.heightVal / 2;
+    const bottom = this.heightVal / 2;
+    const worldMatrix = this.getWorldTransformMatrix();
+
+    return [
+      worldMatrix.transformPoint(left, top),
+      worldMatrix.transformPoint(right, top),
+      worldMatrix.transformPoint(right, bottom),
+      worldMatrix.transformPoint(left, bottom),
+    ];
+  }
+
+  private updateViewportMask(): void {
+    const [topLeft, topRight, bottomRight, bottomLeft] =
+      this.getViewportCorners();
+
+    this.viewportMaskGraphics.clear();
+    this.viewportMaskGraphics.fillStyle(0xffffff, 1);
+    this.viewportMaskGraphics.beginPath();
+    this.viewportMaskGraphics.moveTo(topLeft.x, topLeft.y);
+    this.viewportMaskGraphics.lineTo(topRight.x, topRight.y);
+    this.viewportMaskGraphics.lineTo(bottomRight.x, bottomRight.y);
+    this.viewportMaskGraphics.lineTo(bottomLeft.x, bottomLeft.y);
+    this.viewportMaskGraphics.closePath();
+    this.viewportMaskGraphics.fillPath();
+  }
+
+  private resizeContent(): void {
+    const contentSize = this.sizer.getContentSize();
+    this.sizer.setSize(
+      this.widthVal,
+      Math.max(this.heightVal, contentSize.height),
+    );
+    this.sizer.layout();
+  }
+
+  private onWheel(
+    pointer: Phaser.Input.Pointer,
+    _gameObjects: Phaser.GameObjects.GameObject[],
+    _deltaX: number,
+    _deltaY: number,
+    _deltaZ: number,
+  ): void {
+    if (!this.hasContent()) return;
+
+    const bounds = this.getVisibleAreaBounds();
+    if (
+      pointer.x >= bounds.left &&
+      pointer.x <= bounds.right &&
+      pointer.y >= bounds.top &&
+      pointer.y <= bounds.bottom
+    ) {
+      this.scene.input.stopPropagation();
+
+      const delta = _deltaY > 0 ? 30 : -30;
+      this.scrollY = Phaser.Math.Clamp(
+        this.scrollY + delta,
+        0,
+        this.maxScrollY,
+      );
+      this.updateContent();
+      this.drawScrollbar();
+    }
+  }
+
+  private updateContent(): void {
+    this.sizer.y = (this.sizer.height - this.heightVal) / 2 - this.scrollY;
+  }
+
+  private drawScrollbar(): void {
+    this.scrollbar.clear();
+    this.scrollbarBg.clear();
+
+    if (this.maxScrollY <= 0) return;
+
+    const trackTop = this.visibleArea.top + 4;
+    const trackHeight = Math.max(0, this.visibleArea.height - 8);
+    const trackRight = this.visibleArea.right;
+    if (trackHeight <= 0) return;
+
+    const thumbHeight = Math.min(
+      trackHeight,
+      Math.max(
+        30,
+        this.visibleArea.height *
+          (this.visibleArea.height /
+            (this.visibleArea.height + this.maxScrollY)),
+      ),
+    );
+    const thumbY =
+      trackTop + (this.scrollY / this.maxScrollY) * (trackHeight - thumbHeight);
+
+    this.scrollbarBg.fillStyle(0x333333, 0.5);
+    this.scrollbarBg.fillRoundedRect(
+      trackRight - 8,
+      trackTop,
+      6,
+      trackHeight,
+      3,
+    );
+
+    this.scrollbar.fillStyle(0xffffff, 0.7);
+    this.scrollbar.fillRoundedRect(trackRight - 6, thumbY, 4, thumbHeight, 2);
+  }
+
+  private recalculateMaxScroll(): void {
+    this.maxScrollY = Math.max(0, this.sizer.height - this.heightVal);
+    this.scrollY = Phaser.Math.Clamp(this.scrollY, 0, this.maxScrollY);
+  }
+
+  layout(): void {
+    this.resizeContent();
+    this.updateVisibleArea();
+    this.recalculateMaxScroll();
+    this.updateContent();
+    this.updateViewportMask();
+    this.drawBackground();
+    this.drawScrollbar();
+    this.updateVisibility();
+  }
+
+  setOrigin(_originX: number, _originY?: number): this {
+    return this;
+  }
+
+  override setVisible(_value: boolean): this {
+    this.updateVisibility();
+    return this;
+  }
+
+  override destroy(fromScene?: boolean): void {
+    if (this.scene) {
+      this.scene.input.off("wheel", this.onWheel, this);
+      this.scene.events.off("shutdown", this.destroy, this);
+    }
+    this.sizer.clearMask();
+    this.viewportMask.destroy();
+    this.viewportMaskGraphics.destroy();
+    super.destroy(fromScene);
+  }
+}

--- a/phaser/utils/Sizer.ts
+++ b/phaser/utils/Sizer.ts
@@ -1,0 +1,154 @@
+import * as Phaser from "phaser";
+import type { AnchorConfig } from "./applyAnchor";
+import { applyAnchor } from "./applyAnchor";
+
+export enum Orientation {
+  Horizontal = 0,
+  Vertical = 1,
+}
+
+export interface SizerConfig {
+  orientation?: Orientation;
+  space?: {
+    item?: number;
+    left?: number;
+    right?: number;
+    top?: number;
+    bottom?: number;
+  };
+  anchor?: AnchorConfig;
+}
+
+export class Sizer extends Phaser.GameObjects.Container {
+  private orientation: Orientation;
+  private space: {
+    item: number;
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+  };
+  private anchorConfig?: AnchorConfig;
+  private lastWidth: number = 0;
+  private lastHeight: number = 0;
+
+  constructor(scene: Phaser.Scene, config: SizerConfig = {}) {
+    super(scene);
+    this.orientation = config.orientation ?? Orientation.Vertical;
+    this.space = {
+      item: config.space?.item ?? 0,
+      left: config.space?.left ?? 0,
+      right: config.space?.right ?? 0,
+      top: config.space?.top ?? 0,
+      bottom: config.space?.bottom ?? 0,
+    };
+    this.anchorConfig = config.anchor;
+
+    if (this.parentContainer === null) {
+      scene.add.existing(this);
+    }
+
+    this.layout();
+    if (this.anchorConfig) {
+      applyAnchor(this, this.scene, this.anchorConfig);
+    }
+  }
+
+  preUpdate(): void {
+    let currentWidth: number;
+    let currentHeight: number;
+
+    if (this.parentContainer) {
+      currentWidth = this.parentContainer.width;
+      currentHeight = this.parentContainer.height;
+    } else {
+      currentWidth = this.scene.scale.width;
+      currentHeight = this.scene.scale.height;
+    }
+
+    if (currentWidth !== this.lastWidth || currentHeight !== this.lastHeight) {
+      this.lastWidth = currentWidth;
+      this.lastHeight = currentHeight;
+      if (this.anchorConfig) {
+        applyAnchor(this, this.scene, this.anchorConfig);
+      }
+      this.layout();
+    }
+  }
+
+  destroy(fromScene?: boolean): void {
+    super.destroy(fromScene);
+  }
+
+  addSpace(): this {
+    const space = new Phaser.GameObjects.Rectangle(
+      this.scene,
+      0,
+      0,
+      0,
+      0,
+      0x000000,
+      0.6,
+    );
+    (space as any).isSpace = true;
+    this.add(space);
+    return this;
+  }
+
+  getContentSize(): { width: number; height: number } {
+    const isVertical = this.orientation === Orientation.Vertical;
+    let width = 0;
+    let height = 0;
+
+    for (const child of this.list) {
+      const c = child as any;
+      const childWidth = c.displayWidth || c.width || 0;
+      const childHeight = c.displayHeight || c.height || 0;
+
+      if (isVertical) {
+        width = Math.max(width, childWidth);
+        height += childHeight;
+      } else {
+        width += childWidth;
+        height = Math.max(height, childHeight);
+      }
+    }
+
+    const gapCount = Math.max(0, this.list.length - 1);
+    if (isVertical) {
+      height += gapCount * this.space.item;
+    } else {
+      width += gapCount * this.space.item;
+    }
+
+    return {
+      width: width + this.space.left + this.space.right,
+      height: height + this.space.top + this.space.bottom,
+    };
+  }
+
+  layout(): void {
+    const isVertical = this.orientation === Orientation.Vertical;
+    const halfW = this.width / 2;
+    const halfH = this.height / 2;
+
+    let offsetX = -halfW + this.space.left;
+    let offsetY = -halfH + this.space.top;
+
+    for (const child of this.list) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const c = child as any;
+      const cw = c.displayWidth || c.width || 0;
+      const ch = c.displayHeight || c.height || 0;
+
+      c.x = offsetX + cw / 2;
+      c.y = offsetY + ch / 2;
+
+      if (isVertical) {
+        offsetY += ch + this.space.item;
+      } else {
+        offsetX += cw + this.space.item;
+      }
+    }
+  }
+}

--- a/phaser/utils/applyAnchor.ts
+++ b/phaser/utils/applyAnchor.ts
@@ -1,0 +1,124 @@
+import type * as Phaser from "phaser";
+
+export interface DimensionValue {
+  value: number;
+  type: "percent" | "pixel";
+}
+
+export function setGameObjectPosition(
+  obj: Phaser.GameObjects.GameObject,
+  x: number,
+  y: number,
+): void {
+  if (obj.parentContainer) {
+    (obj as any).x = x;
+    (obj as any).y = y;
+  } else {
+    (obj as any).x = x + obj.scene.scale.width / 2;
+    (obj as any).y = y + obj.scene.scale.height / 2;
+  }
+}
+
+export interface AnchorConfig {
+  left?: number;
+  right?: number;
+  top?: number;
+  bottom?: number;
+  centerX?: boolean;
+  centerY?: boolean;
+  width?: DimensionValue | number;
+  height?: DimensionValue | number;
+  offsetX?: number;
+  offsetY?: number;
+}
+
+/**
+ * Apply anchor-based positioning to a game object.
+ * Compatible with Phaser 3 and 4.
+ *
+ * @example
+ * // Center horizontally and vertically
+ * applyAnchor(obj, scene, { centerX: true, centerY: true });
+ *
+ * // Offset from top by 20px, centered horizontally, 90% width
+ * applyAnchor(obj, scene, {
+ *   top: 20,
+ *   centerX: true,
+ *   width: { value: 90, type: "percent" }
+ * });
+ *
+ * // 100px from right edge, 50px from bottom
+ * applyAnchor(obj, scene, { right: 100, bottom: 50 });
+ */
+export function applyAnchor(
+  obj: Phaser.GameObjects.GameObject,
+  scene: Phaser.Scene,
+  config: AnchorConfig,
+): void {
+  const parent = (obj as any).parentContainer;
+  const parentBounds = parent?.getBounds?.();
+  const parentWidth =
+    parent?.width || parent?.displayWidth || parentBounds?.width;
+  const parentHeight =
+    parent?.height || parent?.displayHeight || parentBounds?.height;
+  const refWidth = parentWidth || scene.scale.width;
+  const refHeight = parentHeight || scene.scale.height;
+
+  let xPos: number | undefined;
+  let yPos: number | undefined;
+
+  const targetW =
+    config.width !== undefined
+      ? typeof config.width === "number"
+        ? config.width
+        : config.width.type === "percent"
+          ? refWidth * (config.width.value / 100)
+          : config.width.value
+      : undefined;
+
+  const targetH =
+    config.height !== undefined
+      ? typeof config.height === "number"
+        ? config.height
+        : config.height.type === "percent"
+          ? refHeight * (config.height.value / 100)
+          : config.height.value
+      : undefined;
+
+  if (targetW !== undefined || targetH !== undefined) {
+    const finalW = targetW ?? (obj as any).displayWidth ?? 0;
+    const finalH = targetH ?? (obj as any).displayHeight ?? 0;
+    if ("setSize" in obj) {
+      (obj as any).setSize(finalW, finalH);
+    }
+    if ("setDisplaySize" in obj) {
+      (obj as any).setDisplaySize(finalW, finalH);
+    }
+  }
+
+  if (config.centerX) {
+    xPos = 0;
+  } else if (config.left !== undefined) {
+    const w = targetW ?? (obj as any).width ?? (obj as any).displayWidth ?? 0;
+    xPos = -refWidth / 2 + config.left + w / 2;
+  } else if (config.right !== undefined) {
+    const w = targetW ?? (obj as any).width ?? (obj as any).displayWidth ?? 0;
+    xPos = refWidth / 2 - config.right - w / 2;
+  }
+
+  if (config.centerY) {
+    yPos = 0;
+  } else if (config.top !== undefined) {
+    const h = targetH ?? (obj as any).height ?? (obj as any).displayHeight ?? 0;
+    yPos = -refHeight / 2 + config.top + h / 2;
+  } else if (config.bottom !== undefined) {
+    const h = targetH ?? (obj as any).height ?? (obj as any).displayHeight ?? 0;
+    yPos = refHeight / 2 - config.bottom - h / 2;
+  }
+
+  if (xPos !== undefined || yPos !== undefined) {
+    const finalX = (xPos ?? (obj as any).x) + (config.offsetX ?? 0);
+    const finalY = (yPos ?? (obj as any).y) + (config.offsetY ?? 0);
+    setGameObjectPosition(obj, finalX, finalY);
+  }
+}

--- a/phaser/utils/common.ts
+++ b/phaser/utils/common.ts
@@ -1,0 +1,96 @@
+export interface ChildConfig {
+  minWidth?: number;
+  minHeight?: number;
+  align?: string;
+  expand?: { width?: boolean; height?: boolean };
+  padding?: { left?: number; right?: number; top?: number; bottom?: number };
+}
+
+const BOUNDS_GRAPHICS_KEY = Symbol("boundsGraphics");
+
+function getLocalDebugRect(gameObject: Phaser.GameObjects.GameObject): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} | null {
+  const obj = gameObject as any;
+  const width = obj.width ?? obj.displayWidth ?? 0;
+  const height = obj.height ?? obj.displayHeight ?? 0;
+
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+
+  if (obj.displayOriginX !== undefined || obj.displayOriginY !== undefined) {
+    return {
+      x: -(obj.displayOriginX ?? 0),
+      y: -(obj.displayOriginY ?? 0),
+      width,
+      height,
+    };
+  }
+
+  return {
+    x: -width / 2,
+    y: -height / 2,
+    width,
+    height,
+  };
+}
+
+export function drawBounds(
+  gameObject: Phaser.GameObjects.GameObject,
+  scene: Phaser.Scene,
+  color: number = 0xff0000,
+  alpha: number = 0.3,
+): void {
+  let g = (gameObject as any)[BOUNDS_GRAPHICS_KEY];
+  if (!g) {
+    g = scene.add.graphics();
+    (gameObject as any)[BOUNDS_GRAPHICS_KEY] = g;
+  }
+
+  g.clear();
+  g.fillStyle(color, alpha);
+  g.lineStyle(2, color, 1);
+
+  const localRect = getLocalDebugRect(gameObject);
+  const worldMatrix = (gameObject as any).getWorldTransformMatrix?.();
+
+  if (localRect && worldMatrix) {
+    const left = localRect.x;
+    const right = localRect.x + localRect.width;
+    const top = localRect.y;
+    const bottom = localRect.y + localRect.height;
+    const topLeft = worldMatrix.transformPoint(left, top);
+    const topRight = worldMatrix.transformPoint(right, top);
+    const bottomRight = worldMatrix.transformPoint(right, bottom);
+    const bottomLeft = worldMatrix.transformPoint(left, bottom);
+
+    g.beginPath();
+    g.moveTo(topLeft.x, topLeft.y);
+    g.lineTo(topRight.x, topRight.y);
+    g.lineTo(bottomRight.x, bottomRight.y);
+    g.lineTo(bottomLeft.x, bottomLeft.y);
+    g.closePath();
+    g.fillPath();
+    g.strokePath();
+  } else {
+    const bounds = (gameObject as any).getBounds?.();
+    if (bounds) {
+      g.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+      g.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
+    }
+  }
+
+  g.setDepth(1_000_000);
+}
+
+export function clearBounds(gameObject: Phaser.GameObjects.GameObject): void {
+  const g = (gameObject as any)[BOUNDS_GRAPHICS_KEY];
+  if (g) {
+    g.destroy();
+    (gameObject as any)[BOUNDS_GRAPHICS_KEY] = undefined;
+  }
+}

--- a/phaser/utils/index.ts
+++ b/phaser/utils/index.ts
@@ -1,0 +1,14 @@
+export type { AnchorConfig } from "./applyAnchor";
+export { applyAnchor } from "./applyAnchor";
+export type { DoubleTapConfig } from "./DoubleTap";
+export { DoubleTap } from "./DoubleTap";
+export type { HTMLInputTextConfig } from "./HTMLInputText";
+export { HTMLInputText } from "./HTMLInputText";
+export { OverlapSizer } from "./OverlapSizer";
+export type {
+  ScrollablePanelBackgroundConfig,
+  ScrollablePanelConfig,
+} from "./ScrollablePanel";
+export { ScrollablePanel } from "./ScrollablePanel";
+export type { SizerConfig } from "./Sizer";
+export { Orientation, Sizer } from "./Sizer";

--- a/src/app/floorplan-v2/FloorplanV2Game.tsx
+++ b/src/app/floorplan-v2/FloorplanV2Game.tsx
@@ -2,9 +2,6 @@
 
 import { ChevronDown, Download, Upload } from "lucide-react";
 import { Game } from "phaser";
-import AnchorPlugin from "phaser3-rex-plugins/plugins/anchor-plugin";
-import GesturesPlugin from "phaser3-rex-plugins/plugins/gestures-plugin";
-import UIPlugin from "phaser3-rex-plugins/templates/ui/ui-plugin";
 import {
   useCallback,
   useEffect,
@@ -57,27 +54,6 @@ export default function FloorplanV2Game() {
         gravity: { x: 0, y: 0 },
         debug: false,
       },
-    },
-    plugins: {
-      scene: [
-        {
-          key: "rexUI",
-          plugin: UIPlugin,
-          mapping: "rexUI",
-        },
-        {
-          key: "rexGestures",
-          plugin: GesturesPlugin,
-          mapping: "rexGestures",
-        },
-      ],
-      global: [
-        {
-          key: "rexAnchor",
-          plugin: AnchorPlugin,
-          start: true,
-        },
-      ],
     },
   }).current;
 

--- a/src/app/floorplan-v2/UIScene.ts
+++ b/src/app/floorplan-v2/UIScene.ts
@@ -1,4 +1,4 @@
-import type AnchorPlugin from "phaser3-rex-plugins/plugins/anchor-plugin";
+import { applyAnchor, DoubleTap, ScrollablePanel } from "@phaser/utils";
 import { getHexNumberByName } from "@/ui/colors";
 import type { FloorplanV2Scene } from "./FloorplanV2Scene";
 import type { StagingPolygon } from "./StagingPolygon";
@@ -202,17 +202,13 @@ class PolygonThumbnail {
       this.mainScene.selectPolygon(this.polygon);
     });
 
-    // Add double-tap detection using RexUI tap plugin
-    this.tapPlugin = (this.scene as any).rexGestures.add
-      .tap(this.thumbnailGraphics, { taps: 2 })
-      .on("tap", () => {
-        // Handle double-tap - ensure polygon is selected and emit event to React layer
-        this.mainScene.selectPolygon(this.polygon);
-        this.mainScene.events.emit(
-          "polygonThumbnailDoubleClicked",
-          this.polygon,
-        );
-      });
+    // Add double-tap detection using DoubleTap
+    this.tapPlugin = new DoubleTap(this.scene, this.thumbnailGraphics, {
+      taps: 2,
+    }).on("tap", () => {
+      this.mainScene.selectPolygon(this.polygon);
+      this.mainScene.events.emit("polygonThumbnailDoubleClicked", this.polygon);
+    });
   }
 
   public updateColor(): void {
@@ -276,10 +272,8 @@ export class UIScene extends Phaser.Scene {
 class ShapesList {
   private uiScene: UIScene;
   private mainScene: FloorplanV2Scene;
-  private container: any; // ScrollablePanel from rexUI
-  private sizer: any; // Vertical sizer inside the scrollable panel
+  private container: ScrollablePanel;
   private thumbnails: PolygonThumbnail[] = [];
-  private isVisible: boolean = false;
   private lastPolygonCount: number = 0;
 
   // Panel configuration
@@ -290,47 +284,37 @@ class ShapesList {
     this.uiScene = uiScene;
     this.mainScene = mainScene;
 
-    // Create vertical sizer for thumbnails
-    this.sizer = uiScene.rexUI.add.sizer({
-      orientation: "y",
-      space: { item: this.THUMBNAIL_MARGIN },
-    });
-
-    // Create scrollable panel using rexUI
-    this.container = uiScene.rexUI.add.scrollablePanel({
+    // Create scrollable panel with internal sizer
+    this.container = new ScrollablePanel(uiScene, {
       x: 0,
       y: 0,
       width: this.PANEL_WIDTH,
-      height: 200, // Will be adjusted dynamically
-      panel: {
-        child: this.sizer,
-      },
+      height: 200,
+      space: { item: this.THUMBNAIL_MARGIN },
     });
 
-    // Add background using rexUI's addBackground method (this will auto-resize)
-    const background = uiScene.rexUI.add
-      .roundRectangle(0, 0, 20, 20, 10, 0x000000, 0.3)
-      .setStrokeStyle(2, 0x333333);
-    this.container.addBackground(background);
-
+    // Add background
     this.container.setOrigin(1.0, 0);
-    // Use anchor plugin to position on right side, 200 units from top
-    (uiScene.plugins.get("rexAnchor")! as AnchorPlugin).add(this.container, {
-      right: "right-10",
-      top: "top+100",
+    this.container.addBackground({
+      fillColor: 0x000000,
+      fillAlpha: 0.3,
+      cornerRadius: 10,
+      strokeColor: 0x333333,
+      strokeWidth: 2,
+    });
+
+    // Position on right side, 200 units from top
+    applyAnchor(this.container, uiScene, {
+      right: 10,
+      top: 100,
+      width: this.PANEL_WIDTH,
+      height: { value: 85, type: "percent" },
     });
 
     // Layout after adding background
     this.container.layout();
 
     this.container.setDepth(1000); // High depth to stay on top
-
-    // Hide initially - positioning will be done when shown
-    this.container.setVisible(false);
-  }
-
-  private updatePosition(): void {
-    // Position is handled by rex anchor plugin, no manual positioning needed
   }
 
   public update(): void {
@@ -338,39 +322,13 @@ class ShapesList {
     const polygons = this.mainScene.getStagingPolygons();
     const totalShapes = polygons.length;
 
-    if (totalShapes === 0 && this.isVisible) {
-      this.hide();
-      this.lastPolygonCount = 0;
-    } else if (totalShapes > 0 && !this.isVisible) {
-      this.show();
-      this.updateShapesList(polygons);
-      this.lastPolygonCount = totalShapes;
-    } else if (
-      totalShapes > 0 &&
-      this.isVisible &&
-      totalShapes !== this.lastPolygonCount
-    ) {
-      // Only update if count changed
+    if (totalShapes !== this.lastPolygonCount) {
       this.updateShapesList(polygons);
       this.lastPolygonCount = totalShapes;
     }
   }
 
-  private show(): void {
-    this.isVisible = true;
-    // Update position when showing since background height is now properly set
-    this.updatePosition();
-    this.container.setVisible(true);
-  }
-
-  private hide(): void {
-    this.isVisible = false;
-    this.container.setVisible(false);
-  }
-
   private updateShapesList(polygons: StagingPolygon[]): void {
-    // Clear existing thumbnails from sizer
-    this.sizer.clear(true);
     // Destroy old thumbnails
     this.thumbnails.forEach((thumbnail) => thumbnail.destroy());
     this.thumbnails = [];
@@ -391,31 +349,11 @@ class ShapesList {
 
       if (thumbnailContainer) {
         this.thumbnails.push(thumbnail);
-        this.sizer.add(thumbnailContainer);
+        this.container.add(thumbnailContainer);
       }
     });
 
-    // Measure actual content height by summing thumbnail container heights and gaps
-    let contentHeight = 0;
-    this.thumbnails.forEach((thumbnail, index) => {
-      const container = thumbnail.getContainer();
-      if (container) {
-        const bounds = container.getBounds();
-        contentHeight += bounds.height;
-
-        // Add margin between thumbnails (but not after the last one)
-        if (index < this.thumbnails.length - 1) {
-          contentHeight += this.THUMBNAIL_MARGIN;
-        }
-      }
-    });
-    const maxViewportHeight = this.uiScene.cameras.main.height - 200; // Leave 200px margin (100px top + 100px bottom)
-    const panelHeight = Math.min(contentHeight, maxViewportHeight);
-
-    // Resize container to fit content but not exceed viewport
-    this.container.setMinSize(this.PANEL_WIDTH, panelHeight);
-
-    // Force layout update for background to resize properly
+    // Update scroll range and content layout without changing the viewport size.
     this.container.layout();
 
     // Set higher depth for thumbnail containers so they're interactive above background

--- a/src/app/floorplan/scenes/FloorPlanScene.ts
+++ b/src/app/floorplan/scenes/FloorPlanScene.ts
@@ -1,5 +1,7 @@
+import { Sizer } from "@phaser/utils";
+import { Orientation } from "@phaser/utils/Sizer";
 import { bind, flatten, pick } from "lodash";
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { mergeLines } from "@/utils/geometry";
 import { Button } from "./Button";
 import { DoorplacementManager } from "./DoorplacementManager";
@@ -20,20 +22,17 @@ export class FloorPlanScene extends Phaser.Scene {
     return this._doors;
   }
 
-  create() {}
-
-  start() {
-    const sizer = this.rexUI.add.sizer({
-      orientation: 0,
-      x: 0,
-      y: 0,
-      anchor: {
-        top: "top+20",
-        centerX: "center",
-        width: "90%",
-      },
+  create() {
+    const sizer = new Sizer(this, {
+      orientation: Orientation.Horizontal,
       space: {
         item: 20,
+      },
+      anchor: {
+        top: 20,
+        centerX: true,
+        width: { value: 90, type: "percent" },
+        height: { value: 100, type: "percent" },
       },
     });
 

--- a/src/app/search/components/DecoBackground1.tsx
+++ b/src/app/search/components/DecoBackground1.tsx
@@ -1,3 +1,5 @@
+import { OverlapSizer } from "@phaser/utils";
+import type * as Phaser from "phaser";
 import type { UIScene } from "@/app/search/scenes/UIScene";
 
 export class DecoBackground1 {
@@ -20,24 +22,18 @@ export class DecoBackground1 {
   }
 
   createBackgroundForDesktop() {
-    // Add decroative elements
-    const sizer = this.scene.rexUI.add.overlapSizer({
-      x: 0,
-      y: 0,
-      anchor: {
-        top: `top+${768 / 2 - this.deco1.height / 2}`,
-        centerX: "center",
-        width: "100%",
-      },
+    const sizer = new OverlapSizer(this.scene, {
+      top: 0,
+      centerX: true,
+      centerY: true,
+      width: { value: 100, type: "percent" },
     });
 
-    sizer.add(this.deco1, {
+    sizer.addChild(this.deco1, {
       minWidth: this.deco1.width,
       minHeight: this.deco1.height,
-      align: "center",
-      key: "deco1",
+      align: "center-center",
       expand: { width: true },
-      aspectRatio: 0,
     });
 
     sizer.layout();

--- a/src/app/search/components/DecoBackground1.tsx
+++ b/src/app/search/components/DecoBackground1.tsx
@@ -27,6 +27,7 @@ export class DecoBackground1 {
       centerX: true,
       centerY: true,
       width: { value: 100, type: "percent" },
+      height: { value: 100, type: "pixel" },
     });
 
     sizer.addChild(this.deco1, {

--- a/src/app/search/scenes/UIScene.ts
+++ b/src/app/search/scenes/UIScene.ts
@@ -1,4 +1,6 @@
 // You can write more code here
+
+import { HTMLInputText, OverlapSizer } from "@phaser/utils";
 import { DecoBackground1 } from "@/app/search/components/DecoBackground1";
 import { createLetterFall } from "@/app/search/components/Letterfall";
 import { MarqueeSearch } from "@/app/search/components/MarqueeSearch";
@@ -40,47 +42,38 @@ export class UIScene extends Phaser.Scene {
       this.pendingMarqueeItems = null;
     }
 
-    const inputText = this.add
-      .rexInputText(0, -12, 200, 20, {
-        text: "hello wawa",
-        fontSize: "24px",
-        color: "#000000",
-        align: "center",
-      })
-      .on("textchange", (inputText: { text: string }) => {
-        createLetterFall(this, inputText.text);
-      });
-
-    const sizer = this.rexUI.add.overlapSizer({
-      x: 0,
-      y: 0,
-      height: 117,
-      anchor: {
-        top: "top+50",
-        centerX: "center",
-        width: "90%",
-      },
-    });
-
-    this.inputBoxBg.depth = 1;
-
-    sizer.add(this.inputBoxBg, {
-      minWidth: 30,
-      minHeight: 5.8,
+    const inputText = new HTMLInputText(this, {
+      width: 200,
+      height: 20,
+      text: "hello wawa",
+      fontSize: "24px",
+      color: "#000000",
       align: "center",
-      key: "inputBoxBg",
-      expand: { width: true },
-      aspectRatio: 0,
+    }).onTextChange((inputText: HTMLInputText) => {
+      createLetterFall(this, inputText.text);
     });
 
-    sizer.add(inputText, {
+    const sizer = new OverlapSizer(this, {
+      top: 50,
+      centerX: true,
+      width: { value: 90, type: "percent" },
+      height: 117,
+    });
+
+    // Add inputBoxBg to sizer
+    sizer.addChild(this.inputBoxBg, {
+      minWidth: 1613.8,
+      minHeight: 117,
+      align: "center-center",
+      expand: { width: true },
+    });
+
+    sizer.addChild(inputText, {
       minWidth: 30,
       minHeight: 5.8,
       align: "center-center",
-      key: "input",
-      expand: { width: true },
-      padding: { left: 65, right: 115, bottom: 25 },
-      aspectRatio: 0,
+      expand: { width: true, height: true },
+      padding: { left: 65, right: 115, bottom: 15 },
     });
 
     sizer.layout();
@@ -126,7 +119,7 @@ export class UIScene extends Phaser.Scene {
       "search_bar",
       undefined,
       596,
-      0,
+      6,
       72,
       111,
       0,
@@ -140,7 +133,7 @@ export class UIScene extends Phaser.Scene {
       "Decoration1",
       undefined,
       1379,
-      0,
+      308,
       736,
       559,
       0,

--- a/src/app/typings/phaser.d.ts
+++ b/src/app/typings/phaser.d.ts
@@ -1,7 +1,0 @@
-declare module "phaser3-rex-plugins/plugins/utils/size/ResizeGameObject";
-
-declare namespace Phaser {
-  interface Scene {
-    rexUI: import("phaser3-rex-plugins/templates/ui/ui-plugin").default;
-  }
-}


### PR DESCRIPTION
This PR removes the usage of phaser3-rex-plugins, instead, many of its applications have been replaced with custom implementation.   
  
`phaser3-rex-plugins` doesn't work well with Phaser 4. So we have to remove this dependency before we can adopt Phaser 4.   
  
When we adopt Phaser 4, we will not re-use any `rex-plugins` and will stay with a custom implementation forever. 