### PR TITLE
upgrade code to phaser 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "next-themes": "^0.4.6",
         "number-to-words": "^1.2.4",
         "openai": "^6.16.0",
-        "phaser": "^3.80.1",
+        "phaser": "^4.2.0",
         "pluralize": "^8.0.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -65,6 +65,39 @@
         "tailwindcss": "^4.1.11",
         "tsx": "^4.21.0",
         "typescript": "5.8.3"
+      }
+    },
+    "../phaser": {
+      "version": "4.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4"
+      },
+      "devDependencies": {
+        "@types/offscreencanvas": "^2019.7.3",
+        "@types/source-map": "^0.5.7",
+        "clean-webpack-plugin": "^4.0.0",
+        "dts-dom": "^3.7.0",
+        "eslint": "^10.2.0",
+        "eslint-plugin-es5": "^1.5.0",
+        "exports-loader": "^5.0.0",
+        "fs-extra": "^11.3.4",
+        "imports-loader": "^5.0.0",
+        "jsdoc": "3.x.x",
+        "jsdom": "^29.0.2",
+        "node-sloc": "^0.2.1",
+        "path": "^0.12.7",
+        "phaser3spectorjs": "^0.0.8",
+        "remove-files-webpack-plugin": "^1.5.0",
+        "source-map": "^0.7.6",
+        "terser-webpack-plugin": "^5.4.0",
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.4",
+        "vivid-cli": "^1.1.2",
+        "webpack": "^5.106.0",
+        "webpack-cli": "^7.0.2",
+        "webpack-shell-plugin": "^0.5.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6434,9 +6467,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/events": {
@@ -9153,12 +9186,12 @@
       }
     },
     "node_modules/phaser": {
-      "version": "3.80.1",
-      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.80.1.tgz",
-      "integrity": "sha512-VQGAWoDOkEpAWYkI+PUADv5Ql+SM0xpLuAMBJHz9tBcOLqjJ2wd8bUhxJgOqclQlLTg97NmMd9MhS75w16x1Cw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.2.0.tgz",
+      "integrity": "sha512-9nSQZs4CJ9+V96i2mRC3BBStBcsQWGJJBRpdFYSbpL40/i/QM+wLofaCYMsxNyDk8WJOlHGZUh3uVRKa7lj6yg==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1"
+        "eventemitter3": "^5.0.4"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "next-themes": "^0.4.6",
     "number-to-words": "^1.2.4",
     "openai": "^6.16.0",
-    "phaser": "^3.80.1",
+    "phaser": "^4.2.0",
     "pluralize": "^8.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/phaser/gameConfig.ts
+++ b/phaser/gameConfig.ts
@@ -1,4 +1,5 @@
 import { getSharedLoadingScene } from "@phaser/loadingScene";
+import Phaser from "phaser";
 
 export function createConfig(secondScene?: Phaser.Types.Scenes.SceneType) {
   const scene: Phaser.Types.Scenes.SceneType[] = [getSharedLoadingScene()];

--- a/phaser/utils/ScrollablePanel.ts
+++ b/phaser/utils/ScrollablePanel.ts
@@ -32,7 +32,6 @@ export class ScrollablePanel extends Phaser.GameObjects.Container {
   private scrollbar: Phaser.GameObjects.Graphics;
   private scrollbarBg: Phaser.GameObjects.Graphics;
   private viewportMaskGraphics: Phaser.GameObjects.Graphics;
-  private viewportMask: Phaser.Display.Masks.GeometryMask;
   private background: Phaser.GameObjects.Graphics | null = null;
   private backgroundConfig: ScrollablePanelBackgroundConfig | null = null;
   private _prevWidth: number;
@@ -70,10 +69,13 @@ export class ScrollablePanel extends Phaser.GameObjects.Container {
     super.add(this.sizer);
 
     this.viewportMaskGraphics = new Phaser.GameObjects.Graphics(scene);
-    this.viewportMask = this.sizer.createGeometryMask(
+    this.sizer.enableFilters();
+    this.sizer.filters?.external.addMask(
       this.viewportMaskGraphics,
+      false,
+      scene.cameras.main,
+      "world",
     );
-    this.sizer.setMask(this.viewportMask);
 
     // Scrollbar background
     this.scrollbarBg = scene.add.graphics();
@@ -330,8 +332,7 @@ export class ScrollablePanel extends Phaser.GameObjects.Container {
       this.scene.input.off("wheel", this.onWheel, this);
       this.scene.events.off("shutdown", this.destroy, this);
     }
-    this.sizer.clearMask();
-    this.viewportMask.destroy();
+    this.sizer.filters?.external.clear();
     this.viewportMaskGraphics.destroy();
     super.destroy(fromScene);
   }

--- a/src/app/floorplan-v2/FloorplanV2Game.tsx
+++ b/src/app/floorplan-v2/FloorplanV2Game.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDown, Download, Upload } from "lucide-react";
-import { Game } from "phaser";
+import Phaser, { Game } from "phaser";
 import {
   useCallback,
   useEffect,

--- a/src/app/floorplan-v2/FloorplanV2Scene.ts
+++ b/src/app/floorplan-v2/FloorplanV2Scene.ts
@@ -1,4 +1,5 @@
 import PolyBool, { type Polygon, type Vec2 } from "@velipso/polybool";
+import Phaser from "phaser";
 import type { FloorPlanColor } from "@/ui/colors";
 import {
   type OriginalRectangle,

--- a/src/app/floorplan-v2/StagingPolygon.ts
+++ b/src/app/floorplan-v2/StagingPolygon.ts
@@ -1,3 +1,4 @@
+import Phaser from "phaser";
 import { type FloorPlanColor, getHexNumberByName } from "@/ui/colors";
 import type { FloorplanV2Scene } from "./FloorplanV2Scene";
 
@@ -107,14 +108,18 @@ export class StagingPolygon extends Phaser.Events.EventEmitter {
       this.phaserGraphics.lineStyle(2, hexColorNumber); // Color border
     }
 
+    const phaserPoints = this.vertices.map(
+      (v) => new Phaser.Math.Vector2(v.x, v.y),
+    );
+
     // Fill and stroke the polygon
-    this.phaserGraphics.fillPoints(this.vertices, true);
-    this.phaserGraphics.strokePoints(this.vertices, true);
+    this.phaserGraphics.fillPoints(phaserPoints, true);
+    this.phaserGraphics.strokePoints(phaserPoints, true);
   }
 
   private updateInteractiveArea(): void {
     const phaserPoints = this.vertices.map(
-      (v) => new Phaser.Geom.Point(v.x, v.y),
+      (v) => new Phaser.Math.Vector2(v.x, v.y),
     );
     const polygon = new Phaser.Geom.Polygon(phaserPoints);
 

--- a/src/app/floorplan-v2/UIScene.ts
+++ b/src/app/floorplan-v2/UIScene.ts
@@ -1,4 +1,5 @@
 import { applyAnchor, DoubleTap, ScrollablePanel } from "@phaser/utils";
+import Phaser from "phaser";
 import { getHexNumberByName } from "@/ui/colors";
 import type { FloorplanV2Scene } from "./FloorplanV2Scene";
 import type { StagingPolygon } from "./StagingPolygon";
@@ -91,8 +92,11 @@ class PolygonThumbnail {
     this.thumbnailGraphics.clear();
     this.thumbnailGraphics.fillStyle(fillColor);
     this.thumbnailGraphics.lineStyle(2, 0xffffff);
-    this.thumbnailGraphics.fillPoints(scaledVertices, true);
-    this.thumbnailGraphics.strokePoints(scaledVertices, true);
+    const phaserPoints = scaledVertices.map(
+      (v) => new Phaser.Math.Vector2(v.x, v.y),
+    );
+    this.thumbnailGraphics.fillPoints(phaserPoints, true);
+    this.thumbnailGraphics.strokePoints(phaserPoints, true);
   }
 
   private createThumbnail(): void {
@@ -187,7 +191,7 @@ class PolygonThumbnail {
   ): void {
     // Create hit area using vertices directly (no shift needed for graphics)
     const hitAreaVertices = vertices.map(
-      (v) => new Phaser.Geom.Point(v.x, v.y),
+      (v) => new Phaser.Math.Vector2(v.x, v.y),
     );
     const polygon = new Phaser.Geom.Polygon(hitAreaVertices);
 

--- a/src/app/floorplan/scenes/DoorplacementManager.ts
+++ b/src/app/floorplan/scenes/DoorplacementManager.ts
@@ -1,4 +1,5 @@
 import { includes } from "lodash";
+import Phaser from "phaser";
 import type { FloorPlanScene } from "@/app/floorplan/scenes/FloorPlanScene";
 
 const DEBUG = false;

--- a/src/app/floorplan/scenes/Room.ts
+++ b/src/app/floorplan/scenes/Room.ts
@@ -1,4 +1,5 @@
 import { noop, throttle } from "lodash";
+import Phaser from "phaser";
 import { getRectangleEdges } from "@/utils/geometry";
 
 type Rect = Phaser.GameObjects.Rectangle;

--- a/src/app/house_layout/FloorplanViewerGame.tsx
+++ b/src/app/house_layout/FloorplanViewerGame.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { Game } from "phaser";
+import Phaser, { Game } from "phaser";
 import {
   useCallback,
   useEffect,

--- a/src/app/house_layout/FloorplanViewerScene.ts
+++ b/src/app/house_layout/FloorplanViewerScene.ts
@@ -1,3 +1,4 @@
+import Phaser from "phaser";
 import { type FloorPlanColor, getHexNumberByName } from "@/ui/colors";
 import { type HouseDef, type RoomDef, ViewerMode } from "./common";
 
@@ -243,28 +244,22 @@ export class FloorplanViewerScene extends Phaser.Scene {
       // Determine color from room metadata (Tailwind-like name) or default gray
       const colorName = (room.color || "gray-500") as FloorPlanColor as any;
       const hexNumber = getHexNumberByName(colorName);
+      const phaserPoints = room.vertices.map(
+        (v) => new Phaser.Math.Vector2(v.x, v.y),
+      );
 
       // Helper to render with optional highlight
       const render = (highlight: boolean) => {
         g.clear();
         g.fillStyle(hexNumber, highlight ? 0.35 : 0.2);
         g.lineStyle(highlight ? 3 : 2, hexNumber, 1);
-        g.fillPoints(
-          room.vertices as unknown as Phaser.Types.Math.Vector2Like[],
-          true,
-        );
-        g.strokePoints(
-          room.vertices as unknown as Phaser.Types.Math.Vector2Like[],
-          true,
-        );
+        g.fillPoints(phaserPoints, true);
+        g.strokePoints(phaserPoints, true);
       };
 
       render(false);
 
       // Make the polygon interactive for potential future interactions
-      const phaserPoints = room.vertices.map(
-        (v) => new Phaser.Geom.Point(v.x, v.y),
-      );
       const poly = new Phaser.Geom.Polygon(phaserPoints);
       g.setInteractive(poly, Phaser.Geom.Polygon.Contains);
 

--- a/src/app/search/components/Letterfall.tsx
+++ b/src/app/search/components/Letterfall.tsx
@@ -1,3 +1,4 @@
+import Phaser from "phaser";
 export function createLetterFall(scene: Phaser.Scene, text: string) {
   const textArray = text.split("");
   const start = Phaser.Math.Between(0, 800);

--- a/src/app/search/components/MarqueeSearch.tsx
+++ b/src/app/search/components/MarqueeSearch.tsx
@@ -1,4 +1,5 @@
 import { debounce, last, sample } from "lodash";
+import Phaser from "phaser";
 import type { UIScene } from "@/app/search/scenes/UIScene";
 import {
   GAP,

--- a/src/app/search/scenes/UIScene.ts
+++ b/src/app/search/scenes/UIScene.ts
@@ -1,5 +1,6 @@
 // You can write more code here
 
+import Phaser from "phaser";
 import { DecoBackground1 } from "@/app/search/components/DecoBackground1";
 import { createLetterFall } from "@/app/search/components/Letterfall";
 import { MarqueeSearch } from "@/app/search/components/MarqueeSearch";

--- a/src/ui/components/ColorMapFrame/ColorMapFramePhaserScene.ts
+++ b/src/ui/components/ColorMapFrame/ColorMapFramePhaserScene.ts
@@ -24,47 +24,6 @@ const NINE_SLICE_INSETS = {
   bottomHeight: 103,
 };
 
-const COLOR_MAP_SHADER = new Phaser.Display.BaseShader(
-  COLOR_MAP_SHADER_KEY,
-  COLOR_MAP_9_SLICE_FRAGMENT_SHADER,
-  undefined,
-  {
-    sourceSize: {
-      type: "2f",
-      value: { x: FRAME_WIDTH, y: FRAME_HEIGHT },
-    },
-    sliceInsets: {
-      type: "4f",
-      value: {
-        x: NINE_SLICE_INSETS.leftWidth,
-        y: NINE_SLICE_INSETS.topHeight,
-        z: NINE_SLICE_INSETS.rightWidth,
-        w: NINE_SLICE_INSETS.bottomHeight,
-      },
-    },
-    outerColor: {
-      type: "3f",
-      value: { x: 0.1216, y: 0.6471, z: 1.0 },
-    },
-    panelTint: {
-      type: "3f",
-      value: { x: 0.9373, y: 0.2667, z: 0.2667 },
-    },
-    panelSourceBounds: {
-      type: "4f",
-      value: { x: 0, y: 0, z: 0, w: 0 },
-    },
-    panelScreenBounds: {
-      type: "4f",
-      value: { x: 0, y: 0, z: 0, w: 0 },
-    },
-    tileTextureSize: {
-      type: "2f",
-      value: { x: 64, y: 64 },
-    },
-  },
-);
-
 export type ColorMapFramePhaserSceneConfig = {
   frameColorHex: string;
   panelTintHex: string;
@@ -74,6 +33,7 @@ export type ColorMapFramePhaserSceneConfig = {
 
 type PanelBounds = {
   x: number;
+  /** Bottom-origin normalized Y coordinate. */
   y: number;
   width: number;
   height: number;
@@ -116,7 +76,6 @@ export class ColorMapFramePhaserScene extends Phaser.Scene {
     this.createCanvasTexture(PANEL_TEXTURE_KEY, PANEL_CANVAS_TEXTURE_KEY);
     this.createCanvasTexture(TILE_TEXTURE_KEY, TILE_CANVAS_TEXTURE_KEY);
     this.createShaderOutput();
-    this.applyShaderUniforms();
     this.applyLayout();
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
@@ -195,7 +154,7 @@ export class ColorMapFramePhaserScene extends Phaser.Scene {
     if (maxX >= minX && maxY >= minY) {
       this.panelBounds = {
         x: minX / FRAME_WIDTH,
-        y: minY / FRAME_HEIGHT,
+        y: (FRAME_HEIGHT - maxY - 1) / FRAME_HEIGHT,
         width: (maxX - minX + 1) / FRAME_WIDTH,
         height: (maxY - minY + 1) / FRAME_HEIGHT,
       };
@@ -206,39 +165,33 @@ export class ColorMapFramePhaserScene extends Phaser.Scene {
   }
 
   private createShaderOutput() {
+    const shaderConfig: Phaser.Types.GameObjects.Shader.ShaderQuadConfig = {
+      name: COLOR_MAP_SHADER_KEY,
+      shaderName: COLOR_MAP_SHADER_KEY,
+      fragmentSource: COLOR_MAP_9_SLICE_FRAGMENT_SHADER,
+      setupUniforms: (setUniform: (name: string, value: unknown) => void) => {
+        const uniforms = this.getShaderUniforms();
+        for (const [name, value] of Object.entries(uniforms)) {
+          setUniform(name, value);
+        }
+      },
+    };
+
     this.shaderOutput = this.add.shader(
-      COLOR_MAP_SHADER,
+      shaderConfig,
       0,
       0,
       FRAME_WIDTH,
       FRAME_HEIGHT,
+      [
+        FRAME_CANVAS_TEXTURE_KEY,
+        MASK_CANVAS_TEXTURE_KEY,
+        PANEL_CANVAS_TEXTURE_KEY,
+        TILE_CANVAS_TEXTURE_KEY,
+      ],
     );
 
     this.shaderOutput.setOrigin(0, 0);
-    this.shaderOutput.setSampler2D("iChannel0", FRAME_CANVAS_TEXTURE_KEY, 0, {
-      wrapS: "clamp_to_edge",
-      wrapT: "clamp_to_edge",
-      minFilter: "linear",
-      magFilter: "linear",
-    });
-    this.shaderOutput.setSampler2D("iChannel1", MASK_CANVAS_TEXTURE_KEY, 1, {
-      wrapS: "clamp_to_edge",
-      wrapT: "clamp_to_edge",
-      minFilter: "linear",
-      magFilter: "linear",
-    });
-    this.shaderOutput.setSampler2D("iChannel2", PANEL_CANVAS_TEXTURE_KEY, 2, {
-      wrapS: "clamp_to_edge",
-      wrapT: "clamp_to_edge",
-      minFilter: "linear",
-      magFilter: "linear",
-    });
-    this.shaderOutput.setSampler2D("iChannel3", TILE_CANVAS_TEXTURE_KEY, 3, {
-      wrapS: "clamp_to_edge",
-      wrapT: "clamp_to_edge",
-      minFilter: "linear",
-      magFilter: "linear",
-    });
   }
 
   private sourceAxisToScreenAxis(
@@ -266,10 +219,10 @@ export class ColorMapFramePhaserScene extends Phaser.Scene {
 
   private getStretchedPanelBounds(): PanelBounds {
     const sourceLeft = this.panelBounds.x * FRAME_WIDTH;
-    const sourceTop = this.panelBounds.y * FRAME_HEIGHT;
+    const sourceBottom = this.panelBounds.y * FRAME_HEIGHT;
     const sourceRight =
       (this.panelBounds.x + this.panelBounds.width) * FRAME_WIDTH;
-    const sourceBottom =
+    const sourceTop =
       (this.panelBounds.y + this.panelBounds.height) * FRAME_HEIGHT;
 
     const screenLeft = this.sourceAxisToScreenAxis(
@@ -278,13 +231,6 @@ export class ColorMapFramePhaserScene extends Phaser.Scene {
       FRAME_WIDTH,
       NINE_SLICE_INSETS.leftWidth,
       NINE_SLICE_INSETS.rightWidth,
-    );
-    const screenTop = this.sourceAxisToScreenAxis(
-      sourceTop,
-      this.previewHeight,
-      FRAME_HEIGHT,
-      NINE_SLICE_INSETS.topHeight,
-      NINE_SLICE_INSETS.bottomHeight,
     );
     const screenRight = this.sourceAxisToScreenAxis(
       sourceRight,
@@ -297,85 +243,67 @@ export class ColorMapFramePhaserScene extends Phaser.Scene {
       sourceBottom,
       this.previewHeight,
       FRAME_HEIGHT,
-      NINE_SLICE_INSETS.topHeight,
       NINE_SLICE_INSETS.bottomHeight,
+      NINE_SLICE_INSETS.topHeight,
+    );
+    const screenTop = this.sourceAxisToScreenAxis(
+      sourceTop,
+      this.previewHeight,
+      FRAME_HEIGHT,
+      NINE_SLICE_INSETS.bottomHeight,
+      NINE_SLICE_INSETS.topHeight,
     );
 
     return {
       x: screenLeft / this.previewWidth,
-      y: screenTop / this.previewHeight,
+      y: screenBottom / this.previewHeight,
       width: Math.max(screenRight - screenLeft, 0) / this.previewWidth,
-      height: Math.max(screenBottom - screenTop, 0) / this.previewHeight,
+      height: Math.max(screenTop - screenBottom, 0) / this.previewHeight,
     };
   }
 
-  private applyShaderUniforms() {
-    if (!this.shaderOutput) {
-      return;
-    }
-
+  private getShaderUniforms(): Record<string, number | number[]> {
     const stretchedPanelBounds = this.getStretchedPanelBounds();
 
-    this.shaderOutput.setUniform(
-      "outerColor.value.x",
-      this.frameColor.red / 255,
-    );
-    this.shaderOutput.setUniform(
-      "outerColor.value.y",
-      this.frameColor.green / 255,
-    );
-    this.shaderOutput.setUniform(
-      "outerColor.value.z",
-      this.frameColor.blue / 255,
-    );
-    this.shaderOutput.setUniform("panelTint.value.x", this.panelTint.red / 255);
-    this.shaderOutput.setUniform(
-      "panelTint.value.y",
-      this.panelTint.green / 255,
-    );
-    this.shaderOutput.setUniform(
-      "panelTint.value.z",
-      this.panelTint.blue / 255,
-    );
-
     const tileFrame = this.textures.getFrame(TILE_CANVAS_TEXTURE_KEY);
-    if (tileFrame) {
-      this.shaderOutput.setUniform("tileTextureSize.value.x", tileFrame.width);
-      this.shaderOutput.setUniform("tileTextureSize.value.y", tileFrame.height);
-    }
 
-    this.shaderOutput.setUniform(
-      "panelSourceBounds.value.x",
-      this.panelBounds.x,
-    );
-    this.shaderOutput.setUniform(
-      "panelSourceBounds.value.y",
-      this.panelBounds.y,
-    );
-    this.shaderOutput.setUniform(
-      "panelSourceBounds.value.z",
-      this.panelBounds.width,
-    );
-    this.shaderOutput.setUniform(
-      "panelSourceBounds.value.w",
-      this.panelBounds.height,
-    );
-    this.shaderOutput.setUniform(
-      "panelScreenBounds.value.x",
-      stretchedPanelBounds.x,
-    );
-    this.shaderOutput.setUniform(
-      "panelScreenBounds.value.y",
-      stretchedPanelBounds.y,
-    );
-    this.shaderOutput.setUniform(
-      "panelScreenBounds.value.z",
-      stretchedPanelBounds.width,
-    );
-    this.shaderOutput.setUniform(
-      "panelScreenBounds.value.w",
-      stretchedPanelBounds.height,
-    );
+    return {
+      iChannel0: 0,
+      iChannel1: 1,
+      iChannel2: 2,
+      iChannel3: 3,
+      resolution: [this.previewWidth, this.previewHeight],
+      sourceSize: [FRAME_WIDTH, FRAME_HEIGHT],
+      sliceInsets: [
+        NINE_SLICE_INSETS.leftWidth,
+        NINE_SLICE_INSETS.bottomHeight,
+        NINE_SLICE_INSETS.rightWidth,
+        NINE_SLICE_INSETS.topHeight,
+      ],
+      outerColor: [
+        this.frameColor.red / 255,
+        this.frameColor.green / 255,
+        this.frameColor.blue / 255,
+      ],
+      panelTint: [
+        this.panelTint.red / 255,
+        this.panelTint.green / 255,
+        this.panelTint.blue / 255,
+      ],
+      panelSourceBounds: [
+        this.panelBounds.x,
+        this.panelBounds.y,
+        this.panelBounds.width,
+        this.panelBounds.height,
+      ],
+      panelScreenBounds: [
+        stretchedPanelBounds.x,
+        stretchedPanelBounds.y,
+        stretchedPanelBounds.width,
+        stretchedPanelBounds.height,
+      ],
+      tileTextureSize: [tileFrame?.width ?? 64, tileFrame?.height ?? 64],
+    };
   }
 
   private applyLayout() {

--- a/src/ui/components/ColorMapFrame/shaders/colorMap9Slice.frag
+++ b/src/ui/components/ColorMapFrame/shaders/colorMap9Slice.frag
@@ -13,7 +13,7 @@ uniform vec4 panelSourceBounds;
 uniform vec4 panelScreenBounds;
 uniform vec2 tileTextureSize;
 
-varying vec2 fragCoord;
+varying vec2 outTexCoord;
 
 // Maps the current output-space coordinate back into the original source image
 // according to the 9-slice insets.
@@ -49,7 +49,8 @@ vec4 writeMaskedPixel(vec4 sourceColor, float maskAlpha, vec3 replacementColor) 
 }
 
 void main() {
-  vec2 screenUv = fragCoord / resolution.xy;
+  vec2 screenUv = outTexCoord;
+  vec2 fragCoord = screenUv * resolution.xy;
   float sourceX = screenAxisToSourceAxis(
     fragCoord.x,
     resolution.x,

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -1,4 +1,5 @@
 import { groupBy, partition } from "lodash";
+import Phaser from "phaser";
 
 // ChatGPT genearted code
 export function getRectangleEdges(


### PR DESCRIPTION
### TL;DR

Upgrades Phaser from v3 to v4 and updates all dependent code to be compatible with the new API.

### What changed?

- Phaser dependency bumped from `^3.80.1` to `^4.2.0`, along with its `eventemitter3` peer dependency to `^5.0.4`.
- Explicit `import Phaser from "phaser"` added to all files that previously relied on Phaser being available as a global.
- `ScrollablePanel` viewport masking migrated from `GeometryMask` / `setMask` to the new Phaser 4 `enableFilters` / `filters.external.addMask` API.
- Polygon rendering calls (`fillPoints`, `strokePoints`) and hit-area construction updated to use `Phaser.Math.Vector2` instead of plain vertex objects or `Phaser.Geom.Point`, matching the stricter typing in Phaser 4.
- `ColorMapFramePhaserScene` shader setup rewritten to use the new `ShaderQuadConfig` object API (with `setupUniforms` callback and texture array) instead of `Phaser.Display.BaseShader` and individual `setSampler2D` / `setUniform` calls. Uniform values are now returned as a plain record of arrays rather than set imperatively.
- Panel bounds Y-axis convention corrected to bottom-origin normalized coordinates to match Phaser 4's coordinate system, with corresponding fixes to `getStretchedPanelBounds` and the fragment shader (`outTexCoord` replaces `fragCoord` as the varying input).

### How to test?

1. Run `npm install` to pull in the updated Phaser 4 package. (if necessary, purge the entire node_modules folder)
2. Open the floorplan-v2 editor and verify polygon drawing, selection hit areas, and thumbnail rendering all behave correctly.
3. Open the search scene and confirm the marquee and letter-fall animations render as expected.
4. Open any view that displays the `ColorMapFrame` and confirm the 9-slice shader renders with correct colors, panel tint, and tile texture.
5. Verify the `ScrollablePanel` clips its content correctly and cleans up without errors on scene shutdown.

### Why make this change?

Phaser 4 introduces breaking API changes that require explicit imports and updated masking, shader, and geometry APIs. Migrating now keeps the project on a supported release and takes advantage of Phaser 4's improvements.